### PR TITLE
Reimagine homepage with avant-garde blog experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -363,3 +363,12 @@ body {
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+@keyframes holoMarquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,313 +1,617 @@
-/**
- * VIB3CODE-0 Holographic AI Blog
- * 
- * Professional AI blog with subtle holographic effects
- * Clean, readable layout focused on content
- */
-
 'use client';
 
-import { useEffect, useState } from 'react';
-import { BlogPost, contentCategories } from '@/lib/blog-config';
+import { useEffect, useMemo, useState } from 'react';
+import type { CSSProperties, FormEvent } from 'react';
+import type { BlogPost } from '@/lib/blog-config';
+import { contentCategories } from '@/lib/blog-config';
+import { contentAPI } from '@/lib/content-api';
 
-interface BlogSection {
+type CategoryKey = keyof typeof contentCategories;
+type CategoryTheme = typeof contentCategories[keyof typeof contentCategories]['holographicTheme'];
+
+interface CategoryScene {
   id: string;
-  title: string;
-  subtitle: string;
-  content: string;
-  posts?: BlogPost[];
-  theme?: typeof contentCategories[keyof typeof contentCategories]['holographicTheme'];
+  key: CategoryKey;
+  label: string;
+  summary: string;
+  theme: CategoryTheme;
+  posts: BlogPost[];
 }
 
-// Simple holographic background effect (no complex visualizers)
-function HolographicBackground() {
+function hexToRgba(hex: string, alpha: number): string {
+  let normalized = hex.replace('#', '');
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+
+  return `rgba(${Number.isFinite(r) ? r : 0}, ${Number.isFinite(g) ? g : 0}, ${
+    Number.isFinite(b) ? b : 0
+  }, ${alpha})`;
+}
+
+function AvantBackdrop() {
+  const [cursor, setCursor] = useState({ x: 50, y: 50 });
+
+  useEffect(() => {
+    const handle = (event: PointerEvent) => {
+      const { innerWidth, innerHeight } = window;
+      if (!innerWidth || !innerHeight) return;
+
+      const x = (event.clientX / innerWidth) * 100;
+      const y = (event.clientY / innerHeight) * 100;
+      setCursor({ x, y });
+    };
+
+    window.addEventListener('pointermove', handle);
+    return () => window.removeEventListener('pointermove', handle);
+  }, []);
+
+  const auroraStyle: CSSProperties = {
+    background: `radial-gradient(circle at ${cursor.x}% ${cursor.y}%, rgba(34, 211, 238, 0.18), transparent 60%)`,
+  };
+
+  const pulseStyle: CSSProperties = {
+    background: `radial-gradient(circle at ${cursor.x}% ${cursor.y}%, rgba(168, 85, 247, 0.25), transparent 55%)`,
+  };
+
+  const gridStyle: CSSProperties = {
+    backgroundImage:
+      'linear-gradient(120deg, rgba(148, 163, 184, 0.07) 1px, transparent 1px), linear-gradient(0deg, rgba(148, 163, 184, 0.04) 1px, transparent 1px)',
+    backgroundSize: '160px 160px',
+    transform: `translate(${(cursor.x - 50) * 0.2}px, ${(cursor.y - 50) * 0.2}px)`,
+  };
+
   return (
-    <div className="fixed inset-0 z-0 pointer-events-none">
-      <div className="absolute inset-0 bg-gradient-to-br from-black via-slate-900 to-black" />
-      <div className="absolute inset-0 bg-gradient-to-t from-transparent via-cyan-500/5 to-transparent animate-pulse" />
-      <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-cyan-500/10 rounded-full blur-3xl animate-pulse" />
-      <div className="absolute bottom-1/4 right-1/4 w-64 h-64 bg-purple-500/10 rounded-full blur-2xl animate-pulse" style={{ animationDelay: '1s' }} />
+    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-black to-slate-950" />
+      <div className="absolute inset-0 mix-blend-screen blur-3xl opacity-70" style={pulseStyle} />
+      <div className="absolute inset-0 mix-blend-screen opacity-70" style={auroraStyle} />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_22%,rgba(59,130,246,0.16),transparent_62%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_78%,rgba(236,72,153,0.16),transparent_68%)]" />
+      <div className="absolute inset-0 opacity-60" style={gridStyle} />
     </div>
   );
 }
 
-// Article card component
-function ArticleCard({ post }: { post: BlogPost }) {
+function LoadingChoreography() {
   return (
-    <article className="bg-black/40 backdrop-blur-sm rounded-lg border border-cyan-500/20 p-6 hover:border-cyan-400/40 transition-all duration-300 group cursor-pointer">
-      <div className="flex justify-between items-start mb-3">
-        <h3 className="text-xl font-bold text-white group-hover:text-cyan-300 transition-colors">
-          {post.title}
-        </h3>
-        <span className="text-sm text-gray-400 whitespace-nowrap ml-4">
-          {post.readingTime} min read
-        </span>
-      </div>
-      <p className="text-gray-300 mb-4 leading-relaxed">
-        {post.excerpt}
-      </p>
-      <div className="flex justify-between items-center mb-4">
-        <time className="text-sm text-cyan-400">
-          {post.publishedAt.toLocaleDateString('en-US', { 
-            year: 'numeric', 
-            month: 'long', 
-            day: 'numeric' 
-          })}
-        </time>
-        <div className="flex items-center space-x-2">
-          {post.author.avatar && (
-            <img 
-              src={post.author.avatar} 
-              alt={post.author.name}
-              className="w-6 h-6 rounded-full"
-            />
-          )}
-          <span className="text-sm text-gray-400">{post.author.name}</span>
+    <div className="flex min-h-screen items-center justify-center bg-black text-white">
+      <div className="relative flex flex-col items-center gap-6">
+        <div className="relative h-32 w-32">
+          <div className="absolute inset-0 rounded-full border border-cyan-500/40 animate-spin" style={{ animationDuration: '18s' }} />
+          <div
+            className="absolute inset-4 rounded-full border border-purple-500/40 animate-spin"
+            style={{ animationDuration: '24s', animationDirection: 'reverse' }}
+          />
+          <div className="absolute inset-10 rounded-full bg-cyan-500/20 blur-2xl" />
+          <div className="absolute inset-[38%] rounded-full bg-white/90 shadow-[0_0_30px_rgba(255,255,255,0.6)]" />
         </div>
+        <p className="text-xs uppercase tracking-[0.6em] text-gray-400">Initializing sequences</p>
       </div>
-      <div className="flex flex-wrap gap-2">
-        {post.tags.slice(0, 3).map((tag) => (
-          <span 
-            key={tag}
-            className="px-2 py-1 bg-cyan-500/20 text-cyan-300 text-xs rounded-full"
-          >
-            {tag}
-          </span>
-        ))}
-      </div>
-    </article>
+    </div>
   );
 }
 
-// Section component
-function BlogSection({ section, isHero = false }: { section: BlogSection, isHero?: boolean }) {
-  if (isHero) {
-    return (
-      <section className="min-h-screen flex items-center justify-center relative z-10">
-        <div className="text-center max-w-4xl mx-auto px-6">
-          <h1 className="text-8xl font-black mb-6 bg-gradient-to-r from-cyan-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent animate-pulse">
-            {section.title}
-          </h1>
-          <h2 className="text-3xl font-light text-gray-200 mb-8">
-            {section.subtitle}
-          </h2>
-          <p className="text-xl text-gray-300 leading-relaxed max-w-2xl mx-auto">
-            {section.content}
-          </p>
-          <div className="mt-12">
-            <button 
-              onClick={() => document.getElementById('ai-news')?.scrollIntoView({ behavior: 'smooth' })}
-              className="bg-gradient-to-r from-cyan-600 to-purple-600 text-white px-8 py-4 rounded-lg font-medium hover:from-cyan-500 hover:to-purple-500 transition-all duration-300 transform hover:scale-105"
-            >
-              Explore Articles
-            </button>
-          </div>
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-black text-white">
+      <div className="max-w-lg rounded-3xl border border-red-500/30 bg-red-500/10 px-10 py-12 text-center backdrop-blur-xl">
+        <h2 className="text-3xl font-semibold text-red-200">Signal disrupted</h2>
+        <p className="mt-4 text-sm text-red-100/80">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function AvantNavigation({ items }: { items: { id: string; label: string }[] }) {
+  const [active, setActive] = useState(items[0]?.id ?? '');
+
+  useEffect(() => {
+    if (!items.length) return;
+    setActive(items[0].id);
+  }, [items]);
+
+  useEffect(() => {
+    if (!items.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.45 }
+    );
+
+    const elements = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => Boolean(el));
+
+    elements.forEach((el) => observer.observe(el));
+
+    return () => {
+      elements.forEach((el) => observer.unobserve(el));
+      observer.disconnect();
+    };
+  }, [items]);
+
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-8 right-8 z-50 hidden lg:block">
+      <div className="relative rounded-[28px] border border-white/10 bg-black/60 px-6 py-6 backdrop-blur-xl">
+        <div className="absolute -inset-1 rounded-[30px] bg-gradient-to-br from-cyan-500/20 via-transparent to-purple-500/20 opacity-80 blur-xl" />
+        <div className="relative flex flex-col gap-4 text-[0.65rem] uppercase tracking-[0.5em] text-gray-400">
+          {items.map((item) => {
+            const isActive = active === item.id;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                aria-current={isActive ? 'page' : undefined}
+                onClick={() => {
+                  document.getElementById(item.id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                  setActive(item.id);
+                }}
+                className={`group text-left transition-all duration-300 ${isActive ? 'text-white' : 'hover:text-cyan-200'}`}
+              >
+                <span className="flex items-center gap-3">
+                  <span className={`h-px w-8 transition-all duration-300 ${isActive ? 'bg-cyan-300' : 'bg-white/20 group-hover:bg-cyan-200'}`} />
+                  {item.label}
+                </span>
+              </button>
+            );
+          })}
         </div>
-      </section>
+      </div>
+    </div>
+  );
+}
+
+function FeaturedOrbit({ featured }: { featured: BlogPost[] }) {
+  if (!featured.length) {
+    return (
+      <div className="rounded-3xl border border-white/10 bg-white/5 px-6 py-10 text-center text-sm text-gray-400 backdrop-blur-xl">
+        Featured transmissions are calibrating.
+      </div>
     );
   }
 
-  const themeColors = section.theme ? {
-    from: section.theme.primaryColor + '40',
-    to: section.theme.primaryColor + '60'
-  } : { from: 'cyan-400', to: 'purple-400' };
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 rounded-3xl bg-gradient-to-r from-cyan-500/10 via-transparent to-purple-500/10 blur-3xl" />
+      <div className="relative overflow-x-auto pb-4">
+        <div className="flex min-w-max gap-6">
+          {featured.map((post) => (
+            <article key={post.id} className="group relative w-72 shrink-0">
+              <div className="absolute -inset-[1px] rounded-[28px] bg-gradient-to-br from-cyan-400/40 via-transparent to-purple-500/40 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+              <div className="relative h-full rounded-[26px] border border-white/10 bg-black/60 p-6 backdrop-blur-xl transition-transform duration-500 group-hover:-translate-y-2">
+                <div className="text-[0.6rem] uppercase tracking-[0.55em] text-gray-500">
+                  {post.category.replace('-', ' ')}
+                </div>
+                <h3 className="mt-4 text-xl font-semibold text-white transition-colors duration-300 group-hover:text-cyan-200">
+                  {post.title}
+                </h3>
+                <p className="mt-3 text-sm text-gray-300">{post.excerpt}</p>
+                <div className="mt-5 flex flex-wrap items-center gap-3 text-xs text-gray-400">
+                  <span>
+                    {post.publishedAt.toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </span>
+                  <span className="h-1 w-1 rounded-full bg-gray-500" />
+                  <span>{post.readingTime} min read</span>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Hero({ featured, scenes }: { featured: BlogPost[]; scenes: CategoryScene[] }) {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(new Date()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const time = now.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
 
   return (
-    <section id={section.id} className="min-h-screen py-20 relative z-10">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="text-center mb-16">
-          <h2 className={`text-6xl font-black mb-4 bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent`}>
-            {section.title}
-          </h2>
-          <h3 className="text-2xl font-light text-gray-300 mb-6">
-            {section.subtitle}
-          </h3>
-          <p className="text-lg text-gray-400 max-w-3xl mx-auto leading-relaxed">
-            {section.content}
-          </p>
+    <section id="hero" className="relative flex min-h-screen items-center justify-center px-6 py-32">
+      <div className="absolute inset-x-1/2 top-24 h-[60vh] w-px -translate-x-1/2 bg-gradient-to-b from-transparent via-cyan-400/40 to-transparent" />
+      <div className="relative z-10 w-full max-w-6xl space-y-16">
+        <div className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between">
+          <div className="max-w-3xl space-y-8">
+            <p className="text-[0.7rem] uppercase tracking-[0.8em] text-cyan-200/70">VIB3CODE — Reactive Hypertext Studio</p>
+            <h1 className="text-6xl font-black leading-[0.95] text-white md:text-8xl">
+              Avant-Garde
+              <span className="block bg-gradient-to-r from-cyan-400 via-purple-400 to-cyan-300 bg-clip-text text-transparent">
+                Intelligence Dispatch
+              </span>
+            </h1>
+            <p className="text-lg text-gray-300 md:text-xl">
+              A polished chronicle of neural aesthetics, critical thought, and creative code. Each dispatch rethinks how AI stories are told—balancing radical experimentation with precise editorial choreography.
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-4 text-right">
+            <span className="text-[0.65rem] uppercase tracking-[0.5em] text-gray-500">Current cycle</span>
+            <span className="font-mono text-2xl text-cyan-200 md:text-3xl">{time}</span>
+            <span className="text-[0.65rem] uppercase tracking-[0.45em] text-gray-500">
+              {scenes.length.toString().padStart(2, '0')} synchronised sequences
+            </span>
+          </div>
         </div>
-
-        {section.posts && section.posts.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {section.posts.map((post) => (
-              <ArticleCard key={post.id} post={post} />
-            ))}
-          </div>
-        )}
-
-        {(!section.posts || section.posts.length === 0) && (
-          <div className="text-center py-12">
-            <div className="text-gray-400">Loading articles...</div>
-          </div>
-        )}
+        <FeaturedOrbit featured={featured} />
+        <div className="flex flex-wrap gap-3">
+          {scenes.map((scene) => (
+            <span
+              key={scene.id}
+              className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.45em] text-white/80 backdrop-blur-md"
+            >
+              {scene.label}
+            </span>
+          ))}
+        </div>
       </div>
     </section>
   );
 }
 
-// Navigation component
-function Navigation({ sections }: { sections: BlogSection[] }) {
-  const [activeSection, setActiveSection] = useState('hero');
+function CategorySceneSection({ scene }: { scene: CategoryScene }) {
+  const accent = scene.theme?.primaryColor ?? '#22d3ee';
+  const accentSoft = hexToRgba(accent, 0.18);
+  const accentMedium = hexToRgba(accent, 0.35);
+  const accentLine = hexToRgba(accent, 0.6);
+  const [hoveredPostId, setHoveredPostId] = useState<string | null>(scene.posts[0]?.id ?? null);
 
   useEffect(() => {
-    if (sections.length === 0) return;
-    
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY + 200;
-      
-      for (const section of sections) {
-        const element = document.getElementById(section.id);
-        if (element && scrollPosition >= element.offsetTop && scrollPosition < element.offsetTop + element.offsetHeight) {
-          setActiveSection(section.id);
-          break;
-        }
-      }
-    };
+    setHoveredPostId(scene.posts[0]?.id ?? null);
+  }, [scene.posts]);
 
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [sections]);
+  const activePost = useMemo(() => {
+    if (!scene.posts.length) return null;
+    return scene.posts.find((post) => post.id === hoveredPostId) ?? scene.posts[0];
+  }, [scene.posts, hoveredPostId]);
+
+  const [primary, ...rest] = scene.posts;
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-sm border-b border-cyan-500/20">
-      <div className="max-w-7xl mx-auto px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div className="text-2xl font-black text-cyan-400">
-            VIB3CODE
-          </div>
-          
-          <div className="hidden md:flex space-x-8">
-            {sections.slice(1).map((section) => (
-              <button
-                key={section.id}
-                onClick={() => document.getElementById(section.id)?.scrollIntoView({ behavior: 'smooth' })}
-                className={`text-sm font-medium transition-colors ${
-                  activeSection === section.id 
-                    ? 'text-cyan-400' 
-                    : 'text-gray-400 hover:text-cyan-300'
-                }`}
+    <section id={scene.id} className="relative py-32">
+      <div
+        className="absolute inset-0 -z-10 opacity-60"
+        style={{ background: `radial-gradient(circle at 30% 20%, ${accentSoft}, transparent 65%)` }}
+      />
+      <div
+        className="absolute inset-0 -z-10 opacity-40"
+        style={{ background: `radial-gradient(circle at 80% 70%, ${accentMedium}, transparent 70%)` }}
+      />
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,2.8fr)_minmax(0,4.2fr)]">
+          <div className="space-y-10">
+            <div className="space-y-3">
+              <p className="text-[0.65rem] uppercase tracking-[0.6em] text-white/60">
+                Sequence — {scene.key.toUpperCase()}
+              </p>
+              <h2 className="text-4xl font-bold text-white md:text-5xl">{scene.label}</h2>
+              <p className="text-base text-gray-300 md:text-lg">{scene.summary}</p>
+            </div>
+            {activePost ? (
+              <div
+                className="rounded-3xl border bg-black/60 p-8 backdrop-blur-xl"
+                style={{ borderColor: accentLine }}
               >
-                {section.title}
+                <div className="text-[0.6rem] uppercase tracking-[0.55em] text-gray-400">Active dispatch</div>
+                <div className="mt-4 text-2xl font-semibold text-white">{activePost.title}</div>
+                <p className="mt-3 text-sm text-gray-300 md:text-base">{activePost.excerpt}</p>
+                <div className="mt-5 flex flex-wrap items-center gap-3 text-xs text-gray-400">
+                  <span>{activePost.author.name}</span>
+                  <span className="h-1 w-1 rounded-full bg-gray-500" />
+                  <span>
+                    {activePost.publishedAt.toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </span>
+                  <span className="h-1 w-1 rounded-full bg-gray-500" />
+                  <span>{activePost.readingTime} min read</span>
+                </div>
+                <div className="mt-6 flex flex-wrap gap-2">
+                  {activePost.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full border border-white/10 px-3 py-1 text-[0.6rem] uppercase tracking-[0.4em] text-white/70"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-3xl border border-dashed border-white/15 p-8 text-sm text-gray-400">
+                We're preparing the next dispatch.
+              </div>
+            )}
+            <div className="flex flex-wrap items-center gap-4">
+              <button
+                type="button"
+                className="rounded-full border border-white/20 bg-white/10 px-6 py-3 text-[0.65rem] uppercase tracking-[0.5em] text-white transition-colors duration-300 hover:border-white/40 hover:bg-white/20"
+              >
+                Enter sequence
               </button>
-            ))}
+              <button
+                type="button"
+                className="rounded-full border border-white/10 px-5 py-3 text-[0.65rem] uppercase tracking-[0.5em] text-gray-300 transition-colors duration-300 hover:border-white/20 hover:text-white"
+              >
+                Archive index
+              </button>
+            </div>
           </div>
-
-          <div className="flex items-center space-x-4">
-            <button className="text-gray-400 hover:text-cyan-400 transition-colors">
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
-              </svg>
-            </button>
+          <div className="space-y-8">
+            {primary ? (
+              <div
+                key={primary.id}
+                onMouseEnter={() => setHoveredPostId(primary.id)}
+                onFocus={() => setHoveredPostId(primary.id)}
+                tabIndex={0}
+                className="group relative overflow-hidden rounded-[32px] border border-white/10 bg-black/60 p-8 outline-none backdrop-blur-2xl transition-transform duration-500 hover:-translate-y-2 focus-visible:-translate-y-2"
+                style={{ boxShadow: `0 20px 60px ${hexToRgba(accent, 0.18)}` }}
+              >
+                <div
+                  className="absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                  style={{ background: `linear-gradient(135deg, ${accentSoft}, transparent 60%)` }}
+                />
+                <div className="relative space-y-4">
+                  <div className="text-[0.6rem] uppercase tracking-[0.5em] text-gray-400">Prime feature</div>
+                  <h3 className="text-3xl font-semibold text-white md:text-4xl">{primary.title}</h3>
+                  <p className="text-sm text-gray-300 md:text-base">{primary.excerpt}</p>
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-gray-400">
+                    <span>{primary.author.name}</span>
+                    <span className="h-1 w-1 rounded-full bg-gray-500" />
+                    <span>
+                      {primary.publishedAt.toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </span>
+                    <span className="h-1 w-1 rounded-full bg-gray-500" />
+                    <span>{primary.readingTime} min read</span>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-3xl border border-dashed border-white/15 p-12 text-center text-sm text-gray-400">
+                Awaiting first feature.
+              </div>
+            )}
+            {rest.length > 0 ? (
+              <div className="grid gap-6 sm:grid-cols-2">
+                {rest.map((post) => (
+                  <article
+                    key={post.id}
+                    onMouseEnter={() => setHoveredPostId(post.id)}
+                    onFocus={() => setHoveredPostId(post.id)}
+                    tabIndex={0}
+                    className="group relative overflow-hidden rounded-[26px] border border-white/10 bg-black/50 p-6 outline-none backdrop-blur-xl transition-transform duration-500 hover:-translate-y-1 focus-visible:-translate-y-1"
+                  >
+                    <div
+                      className="absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                      style={{ background: `linear-gradient(135deg, transparent, ${accentSoft})` }}
+                    />
+                    <div className="relative space-y-3">
+                      <h4 className="text-lg font-semibold text-white transition-colors duration-300 group-hover:text-cyan-200">{post.title}</h4>
+                      <p className="text-sm text-gray-300">{post.excerpt}</p>
+                      <div className="flex flex-wrap items-center gap-3 text-[0.6rem] uppercase tracking-[0.4em] text-gray-400">
+                        <span>
+                          {post.publishedAt.toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                          })}
+                        </span>
+                        <span>{post.readingTime}m</span>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>
-    </nav>
+    </section>
   );
 }
 
-// Admin link (hidden, accessible via URL)
-function AdminLink() {
+function TransmissionPanel() {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!email.trim()) return;
+    setSubmitted(true);
+  };
+
   return (
-    <div className="fixed bottom-4 right-4 z-50">
-      <button
-        onClick={() => window.location.href = '/admin'}
-        className="opacity-20 hover:opacity-100 transition-opacity duration-300 text-xs text-gray-500 hover:text-cyan-400"
-      >
-        Admin
-      </button>
-    </div>
+    <section id="dispatch" className="relative py-32">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_50%_20%,rgba(14,165,233,0.18),transparent_70%)]" />
+      <div className="mx-auto flex max-w-4xl flex-col items-center gap-12 px-6 text-center">
+        <div className="space-y-5">
+          <p className="text-[0.65rem] uppercase tracking-[0.6em] text-gray-400">Stay in the signal</p>
+          <h2 className="text-4xl font-bold text-white md:text-5xl">Subscribe to the avant-garde dispatch</h2>
+          <p className="text-base text-gray-300 md:text-lg">
+            Receive curated releases, behind-the-scenes prototypes, and philosophical riffs. Zero spam—just meticulously engineered transmissions.
+          </p>
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="mx-auto flex w-full max-w-xl flex-col gap-4 rounded-[30px] border border-white/10 bg-black/60 p-6 backdrop-blur-xl sm:flex-row sm:items-center"
+        >
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="your@email"
+            className="w-full rounded-full border border-white/10 bg-black/40 px-6 py-3 text-sm text-white placeholder:text-gray-500 focus:border-cyan-400 focus:outline-none"
+            required
+          />
+          <button
+            type="submit"
+            className="rounded-full border border-white/20 bg-gradient-to-r from-cyan-500 to-purple-500 px-6 py-3 text-sm uppercase tracking-[0.4em] text-white transition-all duration-300 hover:from-cyan-400 hover:to-purple-400"
+          >
+            Join
+          </button>
+        </form>
+        {submitted ? (
+          <div className="text-sm text-cyan-200">Transmission confirmed. Watch your inbox for the next drop.</div>
+        ) : (
+          <div className="text-sm text-gray-400">We only send when something truly shifts the paradigm.</div>
+        )}
+        <div className="overflow-hidden rounded-full border border-white/10 bg-white/5 py-4 backdrop-blur-xl">
+          <div
+            className="flex min-w-max items-center gap-8 text-[0.6rem] uppercase tracking-[0.6em] text-white/70"
+            style={{ animation: 'holoMarquee 26s linear infinite' }}
+          >
+            <span>Meta-Structures</span>
+            <span>Neural Poetry</span>
+            <span>Counterfactuals</span>
+            <span>Synth Designers</span>
+            <span>Meta-Structures</span>
+            <span>Neural Poetry</span>
+            <span>Counterfactuals</span>
+            <span>Synth Designers</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FooterSignature() {
+  return (
+    <footer className="border-t border-white/10 bg-black/60 py-12 text-center text-sm text-gray-400 backdrop-blur-xl">
+      <div className="mx-auto max-w-4xl space-y-3 px-6">
+        <p>VIB3CODE — Reactive HyperAV Studio</p>
+        <p className="text-xs uppercase tracking-[0.5em] text-gray-500">
+          Crafted with deliberate futurism · {new Date().getFullYear()}
+        </p>
+      </div>
+    </footer>
   );
 }
 
 export default function HomePage() {
-  const [sections, setSections] = useState<BlogSection[]>([]);
+  const [scenes, setScenes] = useState<CategoryScene[]>([]);
+  const [featured, setFeatured] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const loadContent = async () => {
+    let active = true;
+
+    const load = async () => {
       try {
-        // Hero section (static content)
-        const heroSection: BlogSection = {
-          id: 'hero',
-          title: 'VIB3CODE',
-          subtitle: 'AI Research & Development Blog',
-          content: 'Exploring the frontiers of artificial intelligence, machine learning, and computational creativity.'
-        };
+        const categoryKeys = Object.keys(contentCategories) as CategoryKey[];
+        const [featuredPosts, sceneResults] = await Promise.all([
+          contentAPI.getFeaturedPosts(),
+          Promise.all(
+            categoryKeys.map(async (key): Promise<CategoryScene> => {
+              const { posts, theme } = await contentAPI.getPostsByCategory(key);
+              return {
+                id: key,
+                key,
+                label: contentCategories[key].name,
+                summary: contentCategories[key].description,
+                theme,
+                posts,
+              };
+            })
+          ),
+        ]);
 
-        // Load content for each category using static content
-        const categoryKeys = Object.keys(contentCategories) as (keyof typeof contentCategories)[];
-        const contentSections: BlogSection[] = [];
+        if (!active) return;
 
-        // Create static content provider
-        const { contentAPI } = await import('@/lib/content-api');
-        
-        for (const categoryKey of categoryKeys) {
-          const category = contentCategories[categoryKey];
-          
-          try {
-            // Get posts for this category from static provider
-            const result = await contentAPI.getPostsByCategory(categoryKey);
-            
-            contentSections.push({
-              id: categoryKey,
-              title: category.name.split(' &')[0], // Shorten for display
-              subtitle: category.name,
-              content: category.description,
-              posts: result.posts || [],
-              theme: category.holographicTheme
-            });
-          } catch (error) {
-            console.error(`Failed to load ${categoryKey} posts:`, error);
-            // Add section without posts
-            contentSections.push({
-              id: categoryKey,
-              title: category.name.split(' &')[0],
-              subtitle: category.name,
-              content: category.description,
-              posts: [],
-              theme: category.holographicTheme
-            });
-          }
+        setFeatured(featuredPosts);
+        setScenes(sceneResults);
+      } catch (err) {
+        console.error('Failed to load blog content', err);
+        if (active) {
+          setError('Our transmissions are recalibrating. Please refresh soon.');
         }
-
-        setSections([heroSection, ...contentSections]);
-        setLoading(false);
-      } catch (error) {
-        console.error('Failed to load content:', error);
-        setLoading(false);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
       }
     };
 
-    loadContent();
+    load();
+
+    return () => {
+      active = false;
+    };
   }, []);
 
+  const navigationItems = useMemo(() => {
+    if (!scenes.length) {
+      return [
+        { id: 'hero', label: 'Origin' },
+        { id: 'dispatch', label: 'Dispatch' },
+      ];
+    }
+
+    return [
+      { id: 'hero', label: 'Origin' },
+      ...scenes.map((scene) => ({ id: scene.id, label: scene.label })),
+      { id: 'dispatch', label: 'Dispatch' },
+    ];
+  }, [scenes]);
+
   if (loading) {
-    return (
-      <div className="min-h-screen bg-black text-white font-[family-name:var(--font-orbitron)] flex items-center justify-center">
-        <div className="text-center">
-          <div className="text-4xl font-bold text-cyan-400 mb-4 animate-pulse">VIB3CODE</div>
-          <div className="text-gray-400">Loading holographic blog...</div>
-        </div>
-      </div>
-    );
+    return <LoadingChoreography />;
+  }
+
+  if (error) {
+    return <ErrorState message={error} />;
   }
 
   return (
-    <div className="min-h-screen bg-black text-white font-[family-name:var(--font-orbitron)]">
-      <HolographicBackground />
-      <Navigation sections={sections} />
-      
-      {/* Hero Section */}
-      {sections.length > 0 && (
-        <BlogSection section={sections[0]} isHero={true} />
-      )}
-      
-      {/* Content Sections */}
-      {sections.slice(1).map((section) => (
-        <BlogSection key={section.id} section={section} />
-      ))}
-
-      <AdminLink />
+    <div className="relative min-h-screen overflow-hidden bg-black text-white">
+      <AvantBackdrop />
+      <AvantNavigation items={navigationItems} />
+      <main className="relative z-10">
+        <Hero featured={featured} scenes={scenes} />
+        <div className="space-y-32">
+          {scenes.map((scene) => (
+            <CategorySceneSection key={scene.id} scene={scene} />
+          ))}
+        </div>
+        <TransmissionPanel />
+      </main>
+      <FooterSignature />
     </div>
   );
 }

--- a/lib/design-system/constants.ts
+++ b/lib/design-system/constants.ts
@@ -1,0 +1,112 @@
+import {
+  CardTransitionsDefinition,
+  HoverResponseDefinition,
+  ClickResponseDefinition,
+  TransitionCoordinationDefinition,
+} from './types';
+
+export const UNIVERSAL_HOVER_RESPONSE: HoverResponseDefinition = {
+  target: {
+    gridDensity: 'increase_2x',
+    colorIntensity: 'increase_1.5x',
+    reactivity: 'increase_1.3x',
+    depth: 'lift_forward_10px',
+  },
+  others: {
+    gridDensity: 'decrease_0.5x',
+    colorIntensity: 'decrease_0.8x',
+    reactivity: 'decrease_0.7x',
+    depth: 'push_back_5px',
+  },
+  transition: {
+    duration: '300ms',
+    easing: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+    stagger: '50ms',
+  },
+};
+
+export const UNIVERSAL_CLICK_RESPONSE: ClickResponseDefinition = {
+  immediate: {
+    colorInversion: 'full_spectrum',
+    variableInversion: {
+      speed: 'reverse_direction',
+      density: 'inverse_value',
+      intensity: 'flip_polarity',
+    },
+    rippleEffect: 'radial_burst',
+    sparkleGeneration: '8_particles',
+  },
+  duration: {
+    inversion: '2000ms',
+    decay: '500ms',
+    sparkles: '1500ms',
+  },
+};
+
+export const TRANSITION_COORDINATION: TransitionCoordinationDefinition = {
+  outgoing: {
+    phase1: 'density_collapse',
+    phase2: 'color_fade_to_black',
+    phase3: 'geometry_dissolve',
+    phase4: 'translucency_to_zero',
+    timing: {
+      phase1: '0ms-400ms',
+      phase2: '200ms-600ms',
+      phase3: '400ms-800ms',
+      phase4: '600ms-1000ms',
+    },
+  },
+  incoming: {
+    phase1: 'translucency_from_zero',
+    phase2: 'geometry_crystallize',
+    phase3: 'color_bloom',
+    phase4: 'density_expansion',
+    timing: {
+      phase1: '500ms-900ms',
+      phase2: '700ms-1100ms',
+      phase3: '900ms-1300ms',
+      phase4: '1100ms-1500ms',
+    },
+  },
+  mathematical_relationship: {
+    density_conservation: 'outgoing_loss = incoming_gain',
+    color_harmonic: 'complementary_color_progression',
+    geometric_morphing: 'shared_mathematical_transform',
+  },
+};
+
+export const CARD_TRANSITIONS_STATES: CardTransitionsDefinition = {
+  emergence: {
+    from_background: {
+      translucency: '0 → 0.8',
+      depth: 'background_layer → foreground_layer',
+      scale: '0.8 → 1.0',
+      geometry_sync: 'background_visualizer_parameters',
+      duration: '1200ms',
+    },
+    from_center: {
+      scale: '0 → 1.0',
+      rotation: '360deg → 0deg',
+      blur: '20px → 0px',
+      emergence_point: 'screen_center',
+      duration: '800ms',
+    },
+  },
+  submersion: {
+    to_background: {
+      translucency: '0.8 → 0',
+      depth: 'foreground_layer → background_layer',
+      scale: '1.0 → 0.8',
+      geometry_sync: 'merge_with_background_visualizer',
+      duration: '1000ms',
+    },
+    to_center: {
+      scale: '1.0 → 0',
+      rotation: '0deg → 360deg',
+      blur: '0px → 20px',
+      convergence_point: 'screen_center',
+      duration: '600ms',
+    },
+  },
+};
+

--- a/lib/design-system/content-integration.ts
+++ b/lib/design-system/content-integration.ts
@@ -1,0 +1,107 @@
+import {
+  ContentManagementDefinition,
+  ScrollableCardsDefinition,
+  VideoExpansionDefinition,
+} from './types';
+
+export const SCROLLABLE_CARDS_CONFIG: ScrollableCardsDefinition = {
+  grid_layout: {
+    columns: 'auto-fit(minmax(250px, 1fr))',
+    gap: '20px',
+    scroll_behavior: 'smooth',
+    scroll_snap: 'y_mandatory',
+    virtualization: 'enabled_for_performance',
+  },
+  scroll_interactions: {
+    visualizer_response: {
+      scroll_up: 'increase_grid_density',
+      scroll_down: 'decrease_grid_density',
+      scroll_velocity: 'affects_animation_speed',
+      scroll_momentum: 'creates_trailing_effects',
+    },
+    content_behavior: {
+      snap_points: 'every_3_items',
+      momentum_scrolling: 'ios_style',
+      edge_bouncing: 'subtle_elastic',
+    },
+  },
+};
+
+export const VIDEO_EXPANSION_CONFIG: VideoExpansionDefinition = {
+  expansion_states: {
+    thumbnail: {
+      size: '100%_of_card',
+      visualizer_role: 'background_ambient',
+      play_button_overlay: 'center_with_glow',
+      controls: 'overlay_button',
+    },
+    playing: {
+      size: '150%_of_original',
+      z_index: '1000',
+      background_blur: 'other_elements',
+      visualizer_role: 'audio_reactive',
+      controls: 'floating_transparent',
+    },
+    fullscreen: {
+      size: '100vw_100vh',
+      background: 'pure_black',
+      visualizer_role: 'immersive_audio_visual',
+      controls: 'minimal_overlay',
+    },
+  },
+  transitions: {
+    thumbnail_to_playing: {
+      duration: '500ms',
+      easing: 'ease_out_expo',
+      visualizer_morph: 'ambient_to_audio_reactive',
+    },
+    playing_to_fullscreen: {
+      duration: '300ms',
+      easing: 'ease_in_out',
+      visualizer_morph: 'audio_reactive_to_immersive',
+    },
+  },
+};
+
+export const CONTENT_MANAGEMENT_CONFIG: ContentManagementDefinition = {
+  sections: [
+    {
+      id: 'section_type',
+      type: 'dropdown',
+      options: ['article_grid', 'video_gallery', 'audio_playlist', 'image_showcase', 'custom_layout'],
+    },
+    {
+      id: 'scrolling',
+      type: 'toggle',
+      options: ['enabled', 'disabled'],
+      subOptions: {
+        enabled: ['smooth', 'snap', 'infinite'],
+        scroll_direction: ['vertical', 'horizontal', 'both'],
+      },
+    },
+    {
+      id: 'expansion',
+      type: 'toggle',
+      options: ['enabled', 'disabled'],
+      subOptions: {
+        enabled: ['click', 'hover', 'auto'],
+        expansion_size: ['1.5x', '2x', 'fullscreen'],
+      },
+    },
+  ],
+  actions: [
+    {
+      id: 'add_content',
+      type: 'button',
+      label: 'Add Content Item',
+      actions: ['open_content_editor'],
+    },
+    {
+      id: 'content_list',
+      type: 'sortable_list',
+      label: 'Content Items',
+      actions: ['edit', 'delete', 'duplicate', 'reorder'],
+    },
+  ],
+};
+

--- a/lib/design-system/editor-config.ts
+++ b/lib/design-system/editor-config.ts
@@ -1,0 +1,217 @@
+import { EditorControlDefinition, EditorPanelDefinition } from './types';
+
+const visualizerControls: EditorControlDefinition[] = [
+  {
+    id: 'visualizer_density',
+    type: 'dropdown',
+    label: 'Density',
+    options: [
+      { label: 'Minimal', value: 'minimal' },
+      { label: 'Standard', value: 'standard' },
+      { label: 'Dense', value: 'dense' },
+      { label: 'Maximum', value: 'maximum' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'visualizer_speed',
+    type: 'dropdown',
+    label: 'Speed',
+    options: [
+      { label: 'Static', value: 'static' },
+      { label: 'Calm', value: 'calm' },
+      { label: 'Flowing', value: 'flowing' },
+      { label: 'Energetic', value: 'energetic' },
+      { label: 'Frenetic', value: 'frenetic' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'visualizer_reactivity',
+    type: 'dropdown',
+    label: 'Reactivity',
+    options: [
+      { label: 'Passive', value: 'passive' },
+      { label: 'Responsive', value: 'responsive' },
+      { label: 'Highly Reactive', value: 'highly_reactive' },
+      { label: 'Hypersensitive', value: 'hypersensitive' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'visualizer_color',
+    type: 'dropdown',
+    label: 'Color Scheme',
+    options: [
+      { label: 'Monochrome', value: 'monochrome' },
+      { label: 'Complementary', value: 'complementary' },
+      { label: 'Triadic', value: 'triadic' },
+      { label: 'Analogous', value: 'analogous' },
+      { label: 'Rainbow', value: 'rainbow' },
+    ],
+    livePreview: true,
+  },
+];
+
+const interactionControls: EditorControlDefinition[] = [
+  {
+    id: 'hover_effect',
+    type: 'dropdown',
+    label: 'Hover Effect',
+    options: [
+      { label: 'Subtle Glow', value: 'subtle_glow' },
+      { label: 'Magnetic Attraction', value: 'magnetic_attraction' },
+      { label: 'Reality Distortion', value: 'reality_distortion' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'click_effect',
+    type: 'dropdown',
+    label: 'Click Effect',
+    options: [
+      { label: 'Color Inversion', value: 'color_inversion' },
+      { label: 'Reality Glitch', value: 'reality_glitch' },
+      { label: 'Quantum Collapse', value: 'quantum_collapse' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'scroll_effect',
+    type: 'dropdown',
+    label: 'Scroll Effect',
+    options: [
+      { label: 'Momentum Trails', value: 'momentum_trails' },
+      { label: 'Chaos Buildup', value: 'chaos_buildup' },
+      { label: 'Harmonic Resonance', value: 'harmonic_resonance' },
+    ],
+    livePreview: true,
+  },
+];
+
+const transitionControls: EditorControlDefinition[] = [
+  {
+    id: 'page_transition',
+    type: 'dropdown',
+    label: 'Page Transition',
+    options: [
+      { label: 'Fade Cross', value: 'fade_cross' },
+      { label: 'Slide Portal', value: 'slide_portal' },
+      { label: 'Spiral Morph', value: 'spiral_morph' },
+      { label: 'Glitch Burst', value: 'glitch_burst' },
+    ],
+    previewActionId: 'test_transition',
+  },
+  {
+    id: 'card_transition',
+    type: 'dropdown',
+    label: 'Card Transition',
+    options: [
+      { label: 'Gentle Emerge', value: 'gentle_emerge' },
+      { label: 'Dramatic Burst', value: 'dramatic_burst' },
+      { label: 'Liquid Flow', value: 'liquid_flow' },
+    ],
+    previewActionId: 'test_card_animation',
+  },
+];
+
+const advancedControls: EditorControlDefinition[] = [
+  {
+    id: 'global_speed_multiplier',
+    type: 'slider',
+    label: 'Global Speed Multiplier',
+    range: [0.1, 3.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+  {
+    id: 'interaction_sensitivity',
+    type: 'slider',
+    label: 'Interaction Sensitivity',
+    range: [0.1, 2.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+  {
+    id: 'transition_duration_multiplier',
+    type: 'slider',
+    label: 'Transition Duration Multiplier',
+    range: [0.5, 2.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+];
+
+export const STYLE_SETTINGS_PANEL: EditorPanelDefinition = {
+  id: 'style_settings',
+  sections: [
+    { id: 'visualizer_configuration', title: 'Visualizer Configuration', controls: visualizerControls },
+    { id: 'interaction_behavior', title: 'Interaction Behavior', controls: interactionControls },
+    { id: 'transition_style', title: 'Transition Style', controls: transitionControls },
+    { id: 'advanced_tuning', title: 'Advanced Tuning', controls: advancedControls },
+  ],
+};
+
+export const CONTENT_MANAGEMENT_PANEL: EditorPanelDefinition = {
+  id: 'content_management',
+  sections: [
+    {
+      id: 'section_configuration',
+      title: 'Section Configuration',
+      controls: [
+        {
+          id: 'section_type',
+          type: 'dropdown',
+          label: 'Section Type',
+          options: [
+            { label: 'Article Grid', value: 'article_grid' },
+            { label: 'Video Gallery', value: 'video_gallery' },
+            { label: 'Audio Playlist', value: 'audio_playlist' },
+            { label: 'Image Showcase', value: 'image_showcase' },
+            { label: 'Custom Layout', value: 'custom_layout' },
+          ],
+        },
+        {
+          id: 'scrolling_toggle',
+          type: 'toggle',
+          label: 'Scrolling',
+          options: [
+            { label: 'Enabled', value: 'enabled' },
+            { label: 'Disabled', value: 'disabled' },
+          ],
+        },
+        {
+          id: 'expansion_toggle',
+          type: 'toggle',
+          label: 'Expansion',
+          options: [
+            { label: 'Enabled', value: 'enabled' },
+            { label: 'Disabled', value: 'disabled' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'content_items',
+      title: 'Content Items',
+      controls: [
+        {
+          id: 'add_content',
+          type: 'button',
+          label: 'Add Content',
+          actions: ['open_content_editor'],
+        },
+        {
+          id: 'content_list',
+          type: 'sortable_list',
+          label: 'Content List',
+          actions: ['edit', 'delete', 'duplicate', 'reorder'],
+        },
+      ],
+    },
+  ],
+};
+

--- a/lib/design-system/index.ts
+++ b/lib/design-system/index.ts
@@ -1,0 +1,9 @@
+export * from './constants';
+export * from './content-integration';
+export * from './editor-config';
+export * from './interaction-coordinator';
+export * from './preset-manager';
+export * from './presets';
+export * from './transition-coordinator';
+export * from './types';
+

--- a/lib/design-system/interaction-coordinator.ts
+++ b/lib/design-system/interaction-coordinator.ts
@@ -1,0 +1,314 @@
+import {
+  ClickEffectPreset,
+  ClickInteractionResult,
+  ClickResponseDefinition,
+  DesignSystemAdvancedTuning,
+  HoverEffectPreset,
+  HoverInteractionResult,
+  HoverResponseDefinition,
+  ParameterPatch,
+  ScrollEffectPreset,
+  ScrollInteractionResult,
+  SectionParameterSnapshot,
+  SectionVisualState,
+  VisualStateMultipliers,
+} from './types';
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+const parseScalarOperation = (operation: string): number => {
+  if (operation.startsWith('increase_')) {
+    const value = operation.replace('increase_', '').replace('x', '');
+    return parseFloat(value);
+  }
+  if (operation.startsWith('decrease_')) {
+    const value = operation.replace('decrease_', '').replace('x', '');
+    return parseFloat(value);
+  }
+  return 1;
+};
+
+const parseDepthOperation = (operation: string): number => {
+  if (operation.startsWith('lift_forward_')) {
+    const value = operation.replace('lift_forward_', '').replace('px', '');
+    return parseFloat(value);
+  }
+  if (operation.startsWith('push_back_')) {
+    const value = operation.replace('push_back_', '').replace('px', '');
+    return -parseFloat(value);
+  }
+  return 0;
+};
+
+const parseDurationMs = (value: string): number => {
+  const match = value.match(/([0-9.]+)ms/);
+  return match ? parseFloat(match[1]) : 0;
+};
+
+const applyMultipliers = (
+  base: SectionVisualState,
+  scalarOps: { gridDensity: string; colorIntensity: string; reactivity: string; depth: string },
+  effect: Partial<VisualStateMultipliers>
+): SectionVisualState => {
+  const gridMultiplier = parseScalarOperation(scalarOps.gridDensity) * (effect.gridDensity ?? 1);
+  const colorMultiplier = parseScalarOperation(scalarOps.colorIntensity) * (effect.colorIntensity ?? 1);
+  const reactivityMultiplier = parseScalarOperation(scalarOps.reactivity) * (effect.reactivity ?? 1);
+  const depthDelta = parseDepthOperation(scalarOps.depth) + (effect.depth ?? 0);
+
+  return {
+    gridDensity: clamp(base.gridDensity * gridMultiplier, 0.1, 4),
+    colorIntensity: clamp(base.colorIntensity * colorMultiplier, 0.2, 4),
+    reactivity: clamp(base.reactivity * reactivityMultiplier, 0.2, 4),
+    depth: clamp(base.depth + depthDelta, -50, 50),
+    inversionActiveUntil: base.inversionActiveUntil,
+    rippleEffect: base.rippleEffect,
+    sparkleEffect: base.sparkleEffect,
+    lastUpdated: Date.now(),
+  };
+};
+
+const mapVisualStateToParams = (
+  visualState: SectionVisualState,
+  baseParams: SectionParameterSnapshot[string],
+  advanced: DesignSystemAdvancedTuning
+): ParameterPatch => {
+  const paramPatch: ParameterPatch = {};
+  paramPatch.density = clamp(baseParams.density * visualState.gridDensity, 0, 1.5);
+  paramPatch.chromaShift = clamp(baseParams.chromaShift * visualState.colorIntensity, -1, 1);
+  const reactivityBoost = visualState.reactivity * advanced.speedMultiplier * advanced.interactionSensitivity;
+  paramPatch.timeScale = clamp(baseParams.timeScale * reactivityBoost, -5, 5);
+  paramPatch.dispAmp = clamp(baseParams.dispAmp + visualState.depth * 0.001, 0, 1.5);
+  return paramPatch;
+};
+
+export const createDefaultSectionVisualState = (): SectionVisualState => ({
+  gridDensity: 1,
+  colorIntensity: 1,
+  reactivity: 1,
+  depth: 0,
+  lastUpdated: Date.now(),
+});
+
+interface HoverInteractionContext {
+  targetId: string;
+  sectionStates: Record<string, SectionVisualState>;
+  params: SectionParameterSnapshot;
+  hoverResponse: HoverResponseDefinition;
+  effect: HoverEffectPreset;
+  advanced: DesignSystemAdvancedTuning;
+  timestamp: number;
+}
+
+export const applyHoverInteraction = ({
+  targetId,
+  sectionStates,
+  params,
+  hoverResponse,
+  effect,
+  advanced,
+  timestamp,
+}: HoverInteractionContext): HoverInteractionResult => {
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  const paramPatches: Record<string, ParameterPatch> = {};
+  const sectionIds = Object.keys(params);
+
+  sectionIds.forEach((sectionId) => {
+    const baseParams = params[sectionId];
+    if (!baseParams) {
+      return;
+    }
+    const baseState = nextStates[sectionId] ?? createDefaultSectionVisualState();
+    const scalarOps = sectionId === targetId ? hoverResponse.target : hoverResponse.others;
+    const modifiers = sectionId === targetId ? effect.targetModifiers : effect.othersModifiers;
+    const updatedState = applyMultipliers(baseState, scalarOps, modifiers ?? {});
+    updatedState.lastUpdated = timestamp;
+
+    nextStates[sectionId] = updatedState;
+    paramPatches[sectionId] = mapVisualStateToParams(updatedState, baseParams, advanced);
+  });
+
+  const baseDuration = parseDurationMs(hoverResponse.transition.duration);
+  const duration = baseDuration * effect.transitionSpeedMultiplier * advanced.transitionDurationMultiplier;
+  const stagger = parseDurationMs(hoverResponse.transition.stagger);
+
+  return {
+    sectionStates: nextStates,
+    paramPatches,
+    transitionDuration: duration,
+    transitionEasing: hoverResponse.transition.easing,
+    stagger,
+  };
+};
+
+interface ClickInteractionContext {
+  targetId: string;
+  sectionStates: Record<string, SectionVisualState>;
+  params: SectionParameterSnapshot;
+  clickResponse: ClickResponseDefinition;
+  effect: ClickEffectPreset;
+  advanced: DesignSystemAdvancedTuning;
+  timestamp: number;
+}
+
+const invertValue = (value: number, min = 0, max = 1): number => clamp(max - (value - min), min, max);
+
+export const applyClickInteraction = ({
+  targetId,
+  sectionStates,
+  params,
+  clickResponse,
+  effect,
+  advanced,
+  timestamp,
+}: ClickInteractionContext): ClickInteractionResult => {
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  const baseState = nextStates[targetId] ?? createDefaultSectionVisualState();
+  const updatedState: SectionVisualState = {
+    ...baseState,
+    inversionActiveUntil: timestamp + effect.inversionDuration,
+    rippleEffect: {
+      type: clickResponse.immediate.rippleEffect,
+      startedAt: timestamp,
+      duration: parseDurationMs(clickResponse.duration.decay),
+    },
+    sparkleEffect: {
+      type: clickResponse.immediate.sparkleGeneration,
+      startedAt: timestamp,
+      duration: effect.sparkleDuration,
+      count: effect.sparkleCount,
+    },
+    lastUpdated: timestamp,
+  };
+
+  nextStates[targetId] = updatedState;
+
+  const baseParams = params[targetId];
+  const paramPatch: ParameterPatch = {};
+  // Apply inversion rules
+  if (clickResponse.immediate.variableInversion.density === 'inverse_value') {
+    paramPatch.density = invertValue(baseParams.density, 0, 1);
+  }
+  if (clickResponse.immediate.variableInversion.intensity === 'flip_polarity') {
+    paramPatch.chromaShift = invertValue(baseParams.chromaShift, -1, 1);
+  }
+  if (clickResponse.immediate.variableInversion.speed === 'reverse_direction') {
+    const reversed = -Math.abs(baseParams.timeScale);
+    paramPatch.timeScale = clamp(reversed, -5, 5) * advanced.speedMultiplier;
+  }
+  paramPatch.glitch = clamp(baseParams.glitch + 0.2, 0, 1);
+
+  const paramPatches: Record<string, ParameterPatch> = { [targetId]: paramPatch };
+
+  return {
+    sectionStates: nextStates,
+    paramPatches,
+  };
+};
+
+interface ScrollInteractionContext {
+  direction: 'up' | 'down';
+  velocity: number;
+  sectionStates: Record<string, SectionVisualState>;
+  params: SectionParameterSnapshot;
+  effect: ScrollEffectPreset;
+  advanced: DesignSystemAdvancedTuning;
+  timestamp: number;
+}
+
+const computeScrollIntensity = (velocity: number, effect: ScrollEffectPreset, timestamp: number): number => {
+  const magnitude = Math.abs(velocity);
+  switch (effect.intensityModel) {
+    case 'velocity':
+      return clamp(magnitude, 0, 4);
+    case 'threshold':
+      return magnitude > (effect.threshold ?? 5) ? clamp(magnitude * 0.5, 0, 4) : 0.2;
+    case 'harmonic':
+      return clamp(2 + Math.sin(timestamp / 300), 0, 4);
+    default:
+      return clamp(magnitude, 0, 4);
+  }
+};
+
+export const applyScrollInteraction = ({
+  direction,
+  velocity,
+  sectionStates,
+  params,
+  effect,
+  advanced,
+  timestamp,
+}: ScrollInteractionContext): ScrollInteractionResult => {
+  const intensity = computeScrollIntensity(velocity, effect, timestamp) * advanced.interactionSensitivity;
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  const paramPatches: Record<string, ParameterPatch> = {};
+
+  Object.keys(params).forEach((sectionId) => {
+    const baseParams = params[sectionId];
+    if (!baseParams) {
+      return;
+    }
+    const baseState = nextStates[sectionId] ?? createDefaultSectionVisualState();
+    const delta = direction === 'up' ? intensity * 0.1 : -intensity * 0.1;
+    const updatedState: SectionVisualState = {
+      ...baseState,
+      gridDensity: clamp(baseState.gridDensity + delta, 0.2, 4),
+      reactivity: clamp(baseState.reactivity + intensity * 0.05, 0.2, 5),
+      colorIntensity: clamp(baseState.colorIntensity + intensity * 0.03, 0.2, 5),
+      depth: clamp(baseState.depth + (direction === 'up' ? 1 : -1) * intensity * 0.5, -50, 50),
+      rippleEffect: effect.decayModel === 'wave' ? {
+        type: 'scroll_wave',
+        startedAt: timestamp,
+        duration: 600,
+      } : baseState.rippleEffect,
+      lastUpdated: timestamp,
+    };
+
+    nextStates[sectionId] = updatedState;
+    paramPatches[sectionId] = mapVisualStateToParams(updatedState, baseParams, advanced);
+  });
+
+  return { sectionStates: nextStates, paramPatches };
+};
+
+export const resetSectionVisualStates = (
+  sectionStates: Record<string, SectionVisualState>,
+  sectionIds?: string[]
+): Record<string, SectionVisualState> => {
+  if (!sectionIds || sectionIds.length === 0) {
+    return {};
+  }
+
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  sectionIds.forEach((id) => {
+    nextStates[id] = createDefaultSectionVisualState();
+  });
+  return nextStates;
+};
+
+export const pruneExpiredEffects = (
+  sectionStates: Record<string, SectionVisualState>,
+  timestamp: number
+): Record<string, SectionVisualState> => {
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  Object.entries(nextStates).forEach(([id, state]) => {
+    if (!state) return;
+    let rippleEffect = state.rippleEffect;
+    if (rippleEffect && timestamp - rippleEffect.startedAt > rippleEffect.duration) {
+      rippleEffect = undefined;
+    }
+    let sparkleEffect = state.sparkleEffect;
+    if (sparkleEffect && timestamp - sparkleEffect.startedAt > sparkleEffect.duration) {
+      sparkleEffect = undefined;
+    }
+    const inversionActive = state.inversionActiveUntil && timestamp > state.inversionActiveUntil;
+
+    nextStates[id] = {
+      ...state,
+      rippleEffect,
+      sparkleEffect,
+      inversionActiveUntil: inversionActive ? undefined : state.inversionActiveUntil,
+    };
+  });
+  return nextStates;
+};
+

--- a/lib/design-system/preset-manager.ts
+++ b/lib/design-system/preset-manager.ts
@@ -1,0 +1,172 @@
+import {
+  cardTransitionPresets,
+  clickEffectPresets,
+  hoverEffectPresets,
+  pageTransitionPresets,
+  scrollEffectPresets,
+  visualizerColorPresets,
+  visualizerDensityPresets,
+  visualizerReactivityPresets,
+  visualizerSpeedPresets,
+} from './presets';
+import {
+  CardTransitionPreset,
+  ClickEffectPreset,
+  DesignSystemAdvancedTuning,
+  HoverEffectPreset,
+  MinimalParamsSnapshot,
+  PageTransitionPreset,
+  ParameterPatch,
+  ScrollEffectPreset,
+  VisualizerColorPreset,
+  VisualizerDensityPreset,
+  VisualizerReactivityPreset,
+  VisualizerSpeedPreset,
+} from './types';
+
+export type PresetCategory =
+  | 'visualizer'
+  | 'speed'
+  | 'reactivity'
+  | 'color'
+  | 'hoverEffect'
+  | 'clickEffect'
+  | 'scrollEffect'
+  | 'pageTransition'
+  | 'cardTransition';
+
+export class PresetManager {
+  private customPresets: Record<string, ParameterPatch> = {};
+
+  list(category: PresetCategory): string[] {
+    switch (category) {
+      case 'visualizer':
+        return Object.keys(visualizerDensityPresets);
+      case 'speed':
+        return Object.keys(visualizerSpeedPresets);
+      case 'reactivity':
+        return Object.keys(visualizerReactivityPresets);
+      case 'color':
+        return Object.keys(visualizerColorPresets);
+      case 'hoverEffect':
+        return Object.keys(hoverEffectPresets);
+      case 'clickEffect':
+        return Object.keys(clickEffectPresets);
+      case 'scrollEffect':
+        return Object.keys(scrollEffectPresets);
+      case 'pageTransition':
+        return Object.keys(pageTransitionPresets);
+      case 'cardTransition':
+        return Object.keys(cardTransitionPresets);
+      default:
+        return [];
+    }
+  }
+
+  get(category: 'visualizer', name: string): VisualizerDensityPreset | undefined;
+  get(category: 'speed', name: string): VisualizerSpeedPreset | undefined;
+  get(category: 'reactivity', name: string): VisualizerReactivityPreset | undefined;
+  get(category: 'color', name: string): VisualizerColorPreset | undefined;
+  get(category: 'hoverEffect', name: string): HoverEffectPreset | undefined;
+  get(category: 'clickEffect', name: string): ClickEffectPreset | undefined;
+  get(category: 'scrollEffect', name: string): ScrollEffectPreset | undefined;
+  get(category: 'pageTransition', name: string): PageTransitionPreset | undefined;
+  get(category: 'cardTransition', name: string): CardTransitionPreset | undefined;
+  get(category: PresetCategory, name: string): unknown {
+    switch (category) {
+      case 'visualizer':
+        return visualizerDensityPresets[name];
+      case 'speed':
+        return visualizerSpeedPresets[name];
+      case 'reactivity':
+        return visualizerReactivityPresets[name];
+      case 'color':
+        return visualizerColorPresets[name];
+      case 'hoverEffect':
+        return hoverEffectPresets[name];
+      case 'clickEffect':
+        return clickEffectPresets[name];
+      case 'scrollEffect':
+        return scrollEffectPresets[name];
+      case 'pageTransition':
+        return pageTransitionPresets[name];
+      case 'cardTransition':
+        return cardTransitionPresets[name];
+      default:
+        return undefined;
+    }
+  }
+
+  computeHomePatch(
+    category: PresetCategory,
+    name: string,
+    base: MinimalParamsSnapshot,
+    advanced: DesignSystemAdvancedTuning
+  ): ParameterPatch | undefined {
+    switch (category) {
+      case 'visualizer':
+        return this.computeVisualizerPatch(name, base);
+      case 'speed':
+        return this.computeSpeedPatch(name, base, advanced);
+      case 'color':
+        return this.computeColorPatch(name);
+      default:
+        return undefined;
+    }
+  }
+
+  registerCustomPreset(name: string, patch: ParameterPatch): void {
+    this.customPresets[name] = patch;
+  }
+
+  getCustomPreset(name: string): ParameterPatch | undefined {
+    return this.customPresets[name];
+  }
+
+  listCustomPresets(): string[] {
+    return Object.keys(this.customPresets);
+  }
+
+  private computeVisualizerPatch(name: string, base: MinimalParamsSnapshot): ParameterPatch | undefined {
+    const preset = visualizerDensityPresets[name];
+    if (!preset) return undefined;
+    const normalized = Math.min(1, Math.max(0.125, preset.base / 32));
+    const variationNormalized = Math.min(1, Math.max(0, preset.variation / 8));
+    const density = Math.min(1.5, 0.2 + normalized * 0.8);
+    const dispAmp = Math.min(1.5, base.dispAmp + variationNormalized * 0.3);
+    return {
+      density,
+      dispAmp,
+    };
+  }
+
+  private computeSpeedPatch(
+    name: string,
+    base: MinimalParamsSnapshot,
+    advanced: DesignSystemAdvancedTuning
+  ): ParameterPatch | undefined {
+    const preset = visualizerSpeedPresets[name];
+    if (!preset) return undefined;
+    const multiplier = 1 + preset.base * 0.5;
+    const timeScale = Math.min(5, Math.max(0.1, base.timeScale * multiplier * advanced.speedMultiplier));
+    const morph = Math.min(2, Math.max(0, base.morph + preset.variation * 0.25));
+    return { timeScale, morph };
+  }
+
+  private computeColorPatch(name: string): ParameterPatch | undefined {
+    const palette = visualizerColorPresets[name];
+    if (!palette) return undefined;
+    const chromaMap: Record<string, number> = {
+      monochrome: 0.02,
+      complementary: 0.06,
+      triadic: 0.08,
+      analogous: 0.05,
+      rainbow: 0.12,
+    };
+    const chromaShift = chromaMap[name] ?? 0.06;
+    return { chromaShift };
+  }
+}
+
+export const createPresetManager = () => new PresetManager();
+

--- a/lib/design-system/presets.ts
+++ b/lib/design-system/presets.ts
@@ -1,0 +1,213 @@
+import {
+  CardTransitionPreset,
+  DesignSystemAdvancedTuning,
+  DesignSystemSelections,
+  HoverEffectPreset,
+  PageTransitionPreset,
+  ScrollEffectPreset,
+  VisualizerColorPreset,
+  VisualizerDensityPreset,
+  VisualizerReactivityPreset,
+  VisualizerSpeedPreset,
+  ClickEffectPreset,
+} from './types';
+
+export const visualizerDensityPresets: Record<string, VisualizerDensityPreset> = {
+  minimal: { base: 4.0, variation: 1.0 },
+  standard: { base: 8.0, variation: 2.0 },
+  dense: { base: 16.0, variation: 4.0 },
+  maximum: { base: 32.0, variation: 8.0 },
+};
+
+export const visualizerSpeedPresets: Record<string, VisualizerSpeedPreset> = {
+  static: { base: 0.0, variation: 0.0 },
+  calm: { base: 0.3, variation: 0.1 },
+  flowing: { base: 0.6, variation: 0.2 },
+  energetic: { base: 1.2, variation: 0.4 },
+  frenetic: { base: 2.0, variation: 0.8 },
+};
+
+export const visualizerReactivityPresets: Record<string, VisualizerReactivityPreset> = {
+  passive: { mouse: 0.2, click: 0.1, scroll: 0.1 },
+  responsive: { mouse: 0.6, click: 0.4, scroll: 0.3 },
+  highly_reactive: { mouse: 1.0, click: 0.8, scroll: 0.6 },
+  hypersensitive: { mouse: 1.5, click: 1.2, scroll: 1.0 },
+};
+
+export const visualizerColorPresets: Record<string, VisualizerColorPreset> = {
+  monochrome: { palette: 'single_hue_variations' },
+  complementary: { palette: 'opposite_color_wheel' },
+  triadic: { palette: 'three_equidistant_hues' },
+  analogous: { palette: 'adjacent_color_wheel' },
+  rainbow: { palette: 'full_spectrum_cycle' },
+};
+
+export const pageTransitionPresets: Record<string, PageTransitionPreset> = {
+  fade_cross: {
+    outgoing: 'fade_to_black',
+    incoming: 'fade_from_black',
+    overlap: '200ms',
+    easing: 'ease_in_out',
+  },
+  slide_portal: {
+    outgoing: 'slide_to_edge_dissolve',
+    incoming: 'slide_from_opposite_edge',
+    overlap: '300ms',
+    easing: 'cubic_bezier_custom',
+  },
+  spiral_morph: {
+    outgoing: 'spiral_collapse_to_center',
+    incoming: 'spiral_emerge_from_center',
+    overlap: '400ms',
+    easing: 'ease_out_expo',
+  },
+  glitch_burst: {
+    outgoing: 'vhs_glitch_dissolve',
+    incoming: 'chromatic_aberration_emerge',
+    overlap: '150ms',
+    easing: 'ease_in_bounce',
+  },
+};
+
+export const cardTransitionPresets: Record<string, CardTransitionPreset> = {
+  gentle_emerge: {
+    from: 'background_layer',
+    animation: 'translucency_and_scale',
+    duration: '800ms',
+    easing: 'ease_out_quart',
+  },
+  dramatic_burst: {
+    from: 'screen_center',
+    animation: 'explosive_scale_and_spin',
+    duration: '1200ms',
+    easing: 'ease_out_back',
+  },
+  liquid_flow: {
+    from: 'edge_of_screen',
+    animation: 'fluid_morph_and_settle',
+    duration: '1500ms',
+    easing: 'ease_out_elastic',
+  },
+};
+
+export const hoverEffectPresets: Record<string, HoverEffectPreset> = {
+  subtle_glow: {
+    name: 'subtle_glow',
+    description: 'soft luminous glow with slight dimming for neighbors',
+    targetModifiers: {
+      gridDensity: 1.05,
+      colorIntensity: 1.2,
+      reactivity: 1.05,
+    },
+    othersModifiers: {
+      gridDensity: 0.9,
+      colorIntensity: 0.92,
+    },
+    transitionSpeedMultiplier: 0.8,
+  },
+  magnetic_attraction: {
+    name: 'magnetic_attraction',
+    description: 'density increase with subtle pull and push dynamics',
+    targetModifiers: {
+      gridDensity: 1.25,
+      colorIntensity: 1.1,
+      reactivity: 1.15,
+      depth: 6,
+    },
+    othersModifiers: {
+      gridDensity: 0.8,
+      reactivity: 0.9,
+      depth: -4,
+    },
+    transitionSpeedMultiplier: 1.0,
+  },
+  reality_distortion: {
+    name: 'reality_distortion',
+    description: 'geometry warping and stability compensation for others',
+    targetModifiers: {
+      gridDensity: 1.4,
+      colorIntensity: 1.35,
+      reactivity: 1.4,
+      depth: 10,
+    },
+    othersModifiers: {
+      gridDensity: 0.7,
+      colorIntensity: 0.85,
+      reactivity: 0.8,
+      depth: -6,
+    },
+    transitionSpeedMultiplier: 1.2,
+  },
+};
+
+export const clickEffectPresets: Record<string, ClickEffectPreset> = {
+  color_inversion: {
+    name: 'color_inversion',
+    description: 'full spectrum flip with exponential decay',
+    colorInversionType: 'spectrum_flip',
+    inversionDuration: 2000,
+    decayCurve: 'exponential',
+    sparkleDuration: 1500,
+    sparkleCount: 8,
+  },
+  reality_glitch: {
+    name: 'reality_glitch',
+    description: 'digital artifact burst with linear decay',
+    colorInversionType: 'digital_artifact_generation',
+    inversionDuration: 1500,
+    decayCurve: 'linear',
+    sparkleDuration: 1200,
+    sparkleCount: 12,
+  },
+  quantum_collapse: {
+    name: 'quantum_collapse',
+    description: 'parameter randomization then stabilization with sigmoid decay',
+    colorInversionType: 'parameter_randomization_then_stabilization',
+    inversionDuration: 3000,
+    decayCurve: 'sigmoid',
+    sparkleDuration: 2000,
+    sparkleCount: 16,
+  },
+};
+
+export const scrollEffectPresets: Record<string, ScrollEffectPreset> = {
+  momentum_trails: {
+    name: 'momentum_trails',
+    description: 'motion blur particles proportional to velocity',
+    intensityModel: 'velocity',
+    decayModel: 'physics',
+  },
+  chaos_buildup: {
+    name: 'chaos_buildup',
+    description: 'progressive distortion released as a portal burst',
+    intensityModel: 'threshold',
+    decayModel: 'burst',
+    threshold: 5,
+    releaseBehavior: 'portal_burst',
+  },
+  harmonic_resonance: {
+    name: 'harmonic_resonance',
+    description: 'coordinated frequency modulation across visualizers',
+    intensityModel: 'harmonic',
+    decayModel: 'wave',
+  },
+};
+
+export const DEFAULT_DESIGN_SYSTEM_SELECTIONS: DesignSystemSelections = {
+  visualizer: 'standard',
+  speed: 'flowing',
+  reactivity: 'responsive',
+  color: 'complementary',
+  hoverEffect: 'magnetic_attraction',
+  clickEffect: 'color_inversion',
+  scrollEffect: 'momentum_trails',
+  pageTransition: 'slide_portal',
+  cardTransition: 'gentle_emerge',
+};
+
+export const DEFAULT_ADVANCED_TUNING: DesignSystemAdvancedTuning = {
+  speedMultiplier: 1.0,
+  interactionSensitivity: 1.0,
+  transitionDurationMultiplier: 1.0,
+};
+

--- a/lib/design-system/transition-coordinator.ts
+++ b/lib/design-system/transition-coordinator.ts
@@ -1,0 +1,73 @@
+import { CARD_TRANSITIONS_STATES, TRANSITION_COORDINATION } from './constants';
+import {
+  CardTransitionEntry,
+  CardTransitionsDefinition,
+  CoordinatedPhaseDefinition,
+  DesignSystemAdvancedTuning,
+} from './types';
+
+export interface TransitionPhaseSchedule {
+  phase: string;
+  start: number;
+  end: number;
+}
+
+const parseRange = (range: string): [number, number] => {
+  const match = range.match(/([0-9.]+)ms-([0-9.]+)ms/);
+  if (!match) return [0, 0];
+  return [parseFloat(match[1]), parseFloat(match[2])];
+};
+
+const buildSchedule = (
+  definition: CoordinatedPhaseDefinition,
+  multiplier: number
+): TransitionPhaseSchedule[] => {
+  const phases: Array<['phase1' | 'phase2' | 'phase3' | 'phase4', string]> = [
+    ['phase1', definition.phase1],
+    ['phase2', definition.phase2],
+    ['phase3', definition.phase3],
+    ['phase4', definition.phase4],
+  ];
+
+  return phases.map(([key, label]) => {
+    const range = definition.timing[key];
+    const [start, end] = parseRange(range);
+    return {
+      phase: label,
+      start: start * multiplier,
+      end: end * multiplier,
+    };
+  });
+};
+
+export class TransitionCoordinator {
+  constructor(
+    private coordination = TRANSITION_COORDINATION,
+    private cardTransitions: CardTransitionsDefinition = CARD_TRANSITIONS_STATES
+  ) {}
+
+  getOutgoingTimeline(tuning: DesignSystemAdvancedTuning): TransitionPhaseSchedule[] {
+    return buildSchedule(
+      this.coordination.outgoing,
+      tuning.transitionDurationMultiplier
+    );
+  }
+
+  getIncomingTimeline(tuning: DesignSystemAdvancedTuning): TransitionPhaseSchedule[] {
+    return buildSchedule(
+      this.coordination.incoming,
+      tuning.transitionDurationMultiplier
+    );
+  }
+
+  getCardTransition(type: 'emergence' | 'submersion', variant: string): CardTransitionEntry | undefined {
+    return this.cardTransitions[type][variant];
+  }
+
+  describeMathematicalRelationship(): Record<string, string> {
+    return this.coordination.mathematical_relationship;
+  }
+}
+
+export const createTransitionCoordinator = () => new TransitionCoordinator();
+

--- a/lib/design-system/types.ts
+++ b/lib/design-system/types.ts
@@ -1,0 +1,346 @@
+// Design system type definitions derived from the VIB34D architecture
+
+export type InteractionOperation = string;
+
+export interface HoverBehaviorOperations {
+  gridDensity: InteractionOperation;
+  colorIntensity: InteractionOperation;
+  reactivity: InteractionOperation;
+  depth: InteractionOperation;
+}
+
+export interface HoverTransitionDefinition {
+  duration: string;
+  easing: string;
+  stagger: string;
+}
+
+export interface HoverResponseDefinition {
+  target: HoverBehaviorOperations;
+  others: HoverBehaviorOperations;
+  transition: HoverTransitionDefinition;
+}
+
+export interface ClickVariableInversionDefinition {
+  speed: InteractionOperation;
+  density: InteractionOperation;
+  intensity: InteractionOperation;
+}
+
+export interface ClickImmediateDefinition {
+  colorInversion: InteractionOperation;
+  variableInversion: ClickVariableInversionDefinition;
+  rippleEffect: InteractionOperation;
+  sparkleGeneration: InteractionOperation;
+}
+
+export interface ClickDurationDefinition {
+  inversion: string;
+  decay: string;
+  sparkles: string;
+}
+
+export interface ClickResponseDefinition {
+  immediate: ClickImmediateDefinition;
+  duration: ClickDurationDefinition;
+}
+
+export interface CoordinatedPhaseDefinition {
+  phase1: string;
+  phase2: string;
+  phase3: string;
+  phase4: string;
+  timing: {
+    phase1: string;
+    phase2: string;
+    phase3: string;
+    phase4: string;
+  };
+}
+
+export interface TransitionCoordinationDefinition {
+  outgoing: CoordinatedPhaseDefinition;
+  incoming: CoordinatedPhaseDefinition;
+  mathematical_relationship: {
+    density_conservation: string;
+    color_harmonic: string;
+    geometric_morphing: string;
+  };
+}
+
+export interface CardTransitionEntry {
+  translucency?: string;
+  depth?: string;
+  scale?: string;
+  geometry_sync?: string;
+  duration: string;
+  rotation?: string;
+  blur?: string;
+  emergence_point?: string;
+  convergence_point?: string;
+}
+
+export interface CardTransitionsDefinition {
+  emergence: Record<string, CardTransitionEntry>;
+  submersion: Record<string, CardTransitionEntry>;
+}
+
+export interface VisualizerDensityPreset {
+  base: number;
+  variation: number;
+}
+
+export interface VisualizerSpeedPreset {
+  base: number;
+  variation: number;
+}
+
+export interface VisualizerReactivityPreset {
+  mouse: number;
+  click: number;
+  scroll: number;
+}
+
+export interface VisualizerColorPreset {
+  palette: string;
+}
+
+export interface PageTransitionPreset {
+  outgoing: string;
+  incoming: string;
+  overlap: string;
+  easing: string;
+}
+
+export interface CardTransitionPreset {
+  from: string;
+  animation: string;
+  duration: string;
+  easing: string;
+}
+
+export interface HoverEffectPreset {
+  name: string;
+  description: string;
+  targetModifiers: Partial<VisualStateMultipliers>;
+  othersModifiers: Partial<VisualStateMultipliers>;
+  transitionSpeedMultiplier: number;
+}
+
+export interface ClickEffectPreset {
+  name: string;
+  description: string;
+  colorInversionType: string;
+  inversionDuration: number;
+  decayCurve: 'exponential' | 'linear' | 'sigmoid';
+  sparkleDuration: number;
+  sparkleCount: number;
+}
+
+export interface ScrollEffectPreset {
+  name: string;
+  description: string;
+  intensityModel: 'velocity' | 'threshold' | 'harmonic';
+  decayModel: 'physics' | 'burst' | 'wave';
+  threshold?: number;
+  releaseBehavior?: string;
+}
+
+export interface VisualStateMultipliers {
+  gridDensity?: number;
+  colorIntensity?: number;
+  reactivity?: number;
+  depth?: number;
+}
+
+export interface InteractionEffectState {
+  type: string;
+  startedAt: number;
+  duration: number;
+  data?: Record<string, number | string>;
+}
+
+export interface SectionVisualState {
+  gridDensity: number;
+  colorIntensity: number;
+  reactivity: number;
+  depth: number;
+  inversionActiveUntil?: number;
+  rippleEffect?: InteractionEffectState;
+  sparkleEffect?: InteractionEffectState & { count: number };
+  lastUpdated: number;
+}
+
+export type ParameterPatch = Partial<{
+  density: number;
+  morph: number;
+  chaos: number;
+  noiseFreq: number;
+  glitch: number;
+  dispAmp: number;
+  chromaShift: number;
+  timeScale: number;
+}>;
+
+export interface MinimalParamsSnapshot {
+  density: number;
+  morph: number;
+  chaos: number;
+  noiseFreq: number;
+  glitch: number;
+  dispAmp: number;
+  chromaShift: number;
+  timeScale: number;
+}
+
+export type SectionParameterSnapshot = Record<string, MinimalParamsSnapshot>;
+
+export interface HoverInteractionResult {
+  sectionStates: Record<string, SectionVisualState>;
+  paramPatches: Record<string, ParameterPatch>;
+  transitionDuration: number;
+  transitionEasing: string;
+  stagger: number;
+}
+
+export interface ClickInteractionResult {
+  sectionStates: Record<string, SectionVisualState>;
+  paramPatches: Record<string, ParameterPatch>;
+}
+
+export interface ScrollInteractionResult {
+  sectionStates: Record<string, SectionVisualState>;
+  paramPatches: Record<string, ParameterPatch>;
+}
+
+export interface DesignSystemSelections {
+  visualizer: string;
+  speed: string;
+  reactivity: string;
+  color: string;
+  hoverEffect: string;
+  clickEffect: string;
+  scrollEffect: string;
+  pageTransition: string;
+  cardTransition: string;
+}
+
+export interface DesignSystemAdvancedTuning {
+  speedMultiplier: number;
+  interactionSensitivity: number;
+  transitionDurationMultiplier: number;
+}
+
+export interface DesignSystemStateSlice {
+  selections: DesignSystemSelections;
+  advanced: DesignSystemAdvancedTuning;
+  sectionStates: Record<string, SectionVisualState>;
+  lastInteraction?: {
+    type: 'hover' | 'click' | 'scroll';
+    at: number;
+    sectionId?: string;
+  };
+  customPresets: Record<string, ParameterPatch>;
+  reactivitySettings?: VisualizerReactivityPreset;
+  colorPalette?: VisualizerColorPreset;
+}
+
+export interface EditorControlOption {
+  label: string;
+  value: string;
+}
+
+export interface EditorControlDefinition {
+  id: string;
+  type: 'dropdown' | 'slider' | 'toggle' | 'button' | 'sortable_list';
+  label: string;
+  options?: EditorControlOption[];
+  range?: [number, number];
+  step?: number;
+  defaultValue?: number | string;
+  livePreview?: boolean;
+  actions?: string[];
+  subOptions?: Record<string, string[]>;
+  previewActionId?: string;
+}
+
+export interface EditorSectionDefinition {
+  id: string;
+  title: string;
+  controls: EditorControlDefinition[];
+}
+
+export interface EditorPanelDefinition {
+  id: string;
+  sections: EditorSectionDefinition[];
+}
+
+export interface ContentSectionBehaviorDefinition {
+  id: string;
+  type: 'dropdown' | 'toggle';
+  options: string[];
+  subOptions?: Record<string, string[]>;
+}
+
+export interface ContentManagementDefinition {
+  sections: ContentSectionBehaviorDefinition[];
+  actions: EditorControlDefinition[];
+}
+
+export interface ScrollableGridLayoutDefinition {
+  columns: string;
+  gap: string;
+  scroll_behavior: string;
+  scroll_snap: string;
+  virtualization: string;
+}
+
+export interface ScrollableVisualizerResponseDefinition {
+  scroll_up: string;
+  scroll_down: string;
+  scroll_velocity: string;
+  scroll_momentum: string;
+}
+
+export interface ScrollableContentBehaviorDefinition {
+  snap_points: string;
+  momentum_scrolling: string;
+  edge_bouncing: string;
+}
+
+export interface ScrollableCardsDefinition {
+  grid_layout: ScrollableGridLayoutDefinition;
+  scroll_interactions: {
+    visualizer_response: ScrollableVisualizerResponseDefinition;
+    content_behavior: ScrollableContentBehaviorDefinition;
+  };
+}
+
+export interface VideoExpansionStateDefinition {
+  size: string;
+  visualizer_role: string;
+  play_button_overlay?: string;
+  z_index?: string;
+  background_blur?: string;
+  controls: string;
+  background?: string;
+}
+
+export interface VideoExpansionTransitionsDefinition {
+  duration: string;
+  easing: string;
+  visualizer_morph: string;
+}
+
+export interface VideoExpansionDefinition {
+  expansion_states: {
+    thumbnail: VideoExpansionStateDefinition;
+    playing: VideoExpansionStateDefinition;
+    fullscreen: VideoExpansionStateDefinition;
+  };
+  transitions: {
+    thumbnail_to_playing: VideoExpansionTransitionsDefinition;
+    playing_to_fullscreen: VideoExpansionTransitionsDefinition;
+  };
+}
+

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,6 +7,31 @@
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
+import {
+  DEFAULT_ADVANCED_TUNING,
+  DEFAULT_DESIGN_SYSTEM_SELECTIONS,
+  UNIVERSAL_HOVER_RESPONSE,
+  UNIVERSAL_CLICK_RESPONSE,
+  hoverEffectPresets,
+  clickEffectPresets,
+  scrollEffectPresets,
+  createPresetManager,
+  applyHoverInteraction,
+  applyClickInteraction,
+  applyScrollInteraction,
+  resetSectionVisualStates,
+  pruneExpiredEffects,
+  createDefaultSectionVisualState,
+} from '@/lib/design-system';
+import type {
+  DesignSystemAdvancedTuning,
+  DesignSystemStateSlice,
+  MinimalParamsSnapshot,
+  ParameterPatch,
+  PresetCategory,
+  SectionParameterSnapshot,
+  SectionVisualState,
+} from '@/lib/design-system';
 
 // EXACT PARAMETER VOCABULARY from PDF specification
 export interface Params {
@@ -163,6 +188,14 @@ export const COUPLING_FACTORS = {
   glitch: 0.15,
 };
 
+const presetManager = createPresetManager();
+
+const createInitialSectionStates = (): Record<string, SectionVisualState> =>
+  Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+    acc[sectionId] = createDefaultSectionVisualState();
+    return acc;
+  }, {} as Record<string, SectionVisualState>);
+
 // State interface
 interface StoreState {
   // Core parameter state
@@ -170,16 +203,19 @@ interface StoreState {
   sections: Record<string, Params>;
   focus?: string;
   beatPhase: number;
-  
+
   // Interaction state
   isHovering: boolean;
   hoverSection?: string;
   scrollProgress: number;
-  
+
   // Audio reactivity
   audioEnabled: boolean;
   audioData: Float32Array | null;
-  
+
+  // Design system
+  designSystem: DesignSystemStateSlice;
+
   // Events and actions
   events: {
     HOVER_START: (id: string) => void;
@@ -190,6 +226,13 @@ interface StoreState {
     UPDATE_HOME: (params: Partial<Params>) => void;
     RANDOMIZE_HOME: () => void;
     TOGGLE_AUDIO: () => void;
+    APPLY_HOVER_RESPONSE: (id: string) => void;
+    APPLY_CLICK_RESPONSE: (id: string) => void;
+    APPLY_SCROLL_RESPONSE: (direction: 'up' | 'down', velocity: number) => void;
+    SET_PRESET: (category: PresetCategory, name: string) => void;
+    SET_ADVANCED_TUNING: (key: keyof DesignSystemAdvancedTuning, value: number) => void;
+    CREATE_CUSTOM_PRESET: (name: string, patch: ParameterPatch) => void;
+    RESET_SECTION_VISUAL_STATE: (sectionId?: string) => void;
   };
 }
 
@@ -250,6 +293,169 @@ export function randomizeHomeParams(): Params {
   };
 }
 
+const computeSectionParams = (
+  home: Params,
+  sections: Record<string, Params>
+): Record<string, Params> => {
+  const resolved: Record<string, Params> = { ...sections };
+  Object.keys(SECTION_CONFIGS).forEach((sectionId) => {
+    if (!resolved[sectionId]) {
+      resolved[sectionId] = deriveParams(home, SECTION_CONFIGS[sectionId].offsets);
+    }
+  });
+  return resolved;
+};
+
+const buildParamsSnapshot = (sections: Record<string, Params>): SectionParameterSnapshot => {
+  return Object.entries(sections).reduce((acc, [sectionId, params]) => {
+    acc[sectionId] = {
+      density: params.density,
+      morph: params.morph,
+      chaos: params.chaos,
+      noiseFreq: params.noiseFreq,
+      glitch: params.glitch,
+      dispAmp: params.dispAmp,
+      chromaShift: params.chromaShift,
+      timeScale: params.timeScale,
+    };
+    return acc;
+  }, {} as SectionParameterSnapshot);
+};
+
+const applyParameterPatches = (
+  sections: Record<string, Params>,
+  patches: Record<string, ParameterPatch>
+): Record<string, Params> => {
+  const updated = { ...sections };
+  Object.entries(patches).forEach(([sectionId, patch]) => {
+    const base = updated[sectionId];
+    if (!base) return;
+    updated[sectionId] = { ...base, ...patch };
+  });
+  return updated;
+};
+
+const toMinimalSnapshot = (params: Params): MinimalParamsSnapshot => ({
+  density: params.density,
+  morph: params.morph,
+  chaos: params.chaos,
+  noiseFreq: params.noiseFreq,
+  glitch: params.glitch,
+  dispAmp: params.dispAmp,
+  chromaShift: params.chromaShift,
+  timeScale: params.timeScale,
+});
+
+const computeHoverResponse = (
+  input: { home: Params; sections: Record<string, Params>; designSystem: DesignSystemStateSlice },
+  targetId: string,
+  timestamp: number
+) => {
+  const ensuredSections = computeSectionParams(input.home, input.sections);
+  let updatedSections = { ...ensuredSections };
+
+  if (SECTION_CONFIGS[targetId]?.transitionIn === 'oppose_snap') {
+    Object.keys(SECTION_CONFIGS).forEach((sectionId) => {
+      if (sectionId !== targetId) {
+        const currentParams = updatedSections[sectionId] || deriveParams(input.home, SECTION_CONFIGS[sectionId].offsets);
+        updatedSections[sectionId] = {
+          ...currentParams,
+          hue: 1.0 - currentParams.hue,
+          density: currentParams.density * 0.85,
+          chromaShift: currentParams.chromaShift + 0.05,
+        };
+      }
+    });
+  }
+
+  const snapshot = buildParamsSnapshot(updatedSections);
+  const hoverEffect =
+    hoverEffectPresets[input.designSystem.selections.hoverEffect] ||
+    hoverEffectPresets.subtle_glow;
+
+  const hoverResult = applyHoverInteraction({
+    targetId,
+    sectionStates: input.designSystem.sectionStates,
+    params: snapshot,
+    hoverResponse: UNIVERSAL_HOVER_RESPONSE,
+    effect: hoverEffect,
+    advanced: input.designSystem.advanced,
+    timestamp,
+  });
+
+  const sections = applyParameterPatches(updatedSections, hoverResult.paramPatches);
+  const designSystem: DesignSystemStateSlice = {
+    ...input.designSystem,
+    sectionStates: hoverResult.sectionStates,
+    lastInteraction: { type: 'hover', at: timestamp, sectionId: targetId },
+  };
+
+  return { sections, designSystem };
+};
+
+const computeClickResponse = (
+  input: { home: Params; sections: Record<string, Params>; designSystem: DesignSystemStateSlice },
+  targetId: string,
+  timestamp: number
+) => {
+  const ensuredSections = computeSectionParams(input.home, input.sections);
+  const snapshot = buildParamsSnapshot(ensuredSections);
+  const clickEffect =
+    clickEffectPresets[input.designSystem.selections.clickEffect] ||
+    clickEffectPresets.color_inversion;
+
+  const clickResult = applyClickInteraction({
+    targetId,
+    sectionStates: input.designSystem.sectionStates,
+    params: snapshot,
+    clickResponse: UNIVERSAL_CLICK_RESPONSE,
+    effect: clickEffect,
+    advanced: input.designSystem.advanced,
+    timestamp,
+  });
+
+  const sections = applyParameterPatches(ensuredSections, clickResult.paramPatches);
+  const designSystem: DesignSystemStateSlice = {
+    ...input.designSystem,
+    sectionStates: clickResult.sectionStates,
+    lastInteraction: { type: 'click', at: timestamp, sectionId: targetId },
+  };
+
+  return { sections, designSystem };
+};
+
+const computeScrollResponse = (
+  input: { home: Params; sections: Record<string, Params>; designSystem: DesignSystemStateSlice },
+  direction: 'up' | 'down',
+  velocity: number,
+  timestamp: number
+) => {
+  const ensuredSections = computeSectionParams(input.home, input.sections);
+  const snapshot = buildParamsSnapshot(ensuredSections);
+  const scrollEffect =
+    scrollEffectPresets[input.designSystem.selections.scrollEffect] ||
+    scrollEffectPresets.momentum_trails;
+
+  const scrollResult = applyScrollInteraction({
+    direction,
+    velocity,
+    sectionStates: input.designSystem.sectionStates,
+    params: snapshot,
+    effect: scrollEffect,
+    advanced: input.designSystem.advanced,
+    timestamp,
+  });
+
+  const sections = applyParameterPatches(ensuredSections, scrollResult.paramPatches);
+  const designSystem: DesignSystemStateSlice = {
+    ...input.designSystem,
+    sectionStates: scrollResult.sectionStates,
+    lastInteraction: { type: 'scroll', at: timestamp },
+  };
+
+  return { sections, designSystem };
+};
+
 // MAIN ZUSTAND STORE
 export const useStore = create<StoreState>()(
   subscribeWithSelector((set, get) => ({
@@ -265,55 +471,74 @@ export const useStore = create<StoreState>()(
     
     audioEnabled: false,
     audioData: null,
-    
+
+    designSystem: {
+      selections: { ...DEFAULT_DESIGN_SYSTEM_SELECTIONS },
+      advanced: { ...DEFAULT_ADVANCED_TUNING },
+      sectionStates: createInitialSectionStates(),
+      lastInteraction: undefined,
+      customPresets: {},
+      reactivitySettings: presetManager.get('reactivity', DEFAULT_DESIGN_SYSTEM_SELECTIONS.reactivity) || undefined,
+      colorPalette: presetManager.get('color', DEFAULT_DESIGN_SYSTEM_SELECTIONS.color) || undefined,
+    },
+
     // Event handlers
     events: {
       HOVER_START: (id: string) => {
         set((state) => {
-          const newState = { ...state, isHovering: true, hoverSection: id };
-          
-          // Apply Oppose & Snap pattern (PDF page 3-4)
-          if (SECTION_CONFIGS[id]?.transitionIn === 'oppose_snap') {
-            const updatedSections = { ...state.sections };
-            
-            // Update all sections with complementary reactions
-            Object.keys(SECTION_CONFIGS).forEach((sectionId) => {
-              if (sectionId !== id) {
-                const currentParams = updatedSections[sectionId] || deriveParams(state.home, SECTION_CONFIGS[sectionId].offsets);
-                // Invert hue for non-focused sections
-                updatedSections[sectionId] = {
-                  ...currentParams,
-                  hue: 1.0 - currentParams.hue,
-                  density: currentParams.density * 0.85, // Coupling factor
-                  chromaShift: currentParams.chromaShift + 0.05,
-                };
-              }
-            });
-            
-            newState.sections = updatedSections;
-          }
-          
-          return newState;
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeHoverResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            id,
+            timestamp
+          );
+
+          return {
+            ...state,
+            isHovering: true,
+            hoverSection: id,
+            sections,
+            designSystem,
+          };
         });
       },
       
-      HOVER_END: (id: string) => {
-        set((state) => ({
-          ...state,
-          isHovering: false,
-          hoverSection: undefined,
-          // Reset sections to derived state
-          sections: Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+      HOVER_END: (_id: string) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const baseSections = Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
             acc[sectionId] = deriveParams(state.home, SECTION_CONFIGS[sectionId].offsets);
             return acc;
-          }, {} as Record<string, Params>),
-        }));
+          }, {} as Record<string, Params>);
+
+          const resetStates = resetSectionVisualStates(
+            state.designSystem.sectionStates,
+            Object.keys(SECTION_CONFIGS)
+          );
+
+          return {
+            ...state,
+            isHovering: false,
+            hoverSection: undefined,
+            sections: baseSections,
+            designSystem: {
+              ...state.designSystem,
+              sectionStates: resetStates,
+              lastInteraction: { type: 'hover', at: timestamp },
+            },
+          };
+        });
       },
       
       TICK: (dt: number) => {
+        const timestamp = Date.now();
         set((state) => ({
           ...state,
-          beatPhase: (state.beatPhase + dt * 0.5) % 1.0, // Update beat phase
+          beatPhase: (state.beatPhase + dt * 0.5) % 1.0,
+          designSystem: {
+            ...state.designSystem,
+            sectionStates: pruneExpiredEffects(state.designSystem.sectionStates, timestamp),
+          },
         }));
       },
       
@@ -367,6 +592,157 @@ export const useStore = create<StoreState>()(
       
       TOGGLE_AUDIO: () => {
         set((state) => ({ ...state, audioEnabled: !state.audioEnabled }));
+      },
+
+      APPLY_HOVER_RESPONSE: (id: string) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeHoverResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            id,
+            timestamp
+          );
+          return {
+            ...state,
+            sections,
+            designSystem,
+          };
+        });
+      },
+
+      APPLY_CLICK_RESPONSE: (id: string) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeClickResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            id,
+            timestamp
+          );
+          return {
+            ...state,
+            sections,
+            designSystem,
+          };
+        });
+      },
+
+      APPLY_SCROLL_RESPONSE: (direction: 'up' | 'down', velocity: number) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeScrollResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            direction,
+            velocity,
+            timestamp
+          );
+          return {
+            ...state,
+            sections,
+            designSystem,
+          };
+        });
+      },
+
+      SET_PRESET: (category: PresetCategory, name: string) => {
+        set((state) => {
+          const selections = { ...state.designSystem.selections, [category]: name };
+          let advanced = { ...state.designSystem.advanced };
+          let reactivitySettings = state.designSystem.reactivitySettings;
+          let colorPalette = state.designSystem.colorPalette;
+          let home = state.home;
+          let sections = state.sections;
+
+          const timestamp = Date.now();
+
+          if (category === 'reactivity') {
+            const preset = presetManager.get('reactivity', name);
+            if (preset) {
+              advanced = {
+                ...advanced,
+                interactionSensitivity: preset.mouse,
+              };
+              reactivitySettings = preset;
+            }
+          }
+
+          if (category === 'color') {
+            const patch = presetManager.computeHomePatch('color', name, toMinimalSnapshot(state.home), advanced);
+            if (patch) {
+              home = { ...state.home, ...patch };
+              sections = Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+                acc[sectionId] = deriveParams(home, SECTION_CONFIGS[sectionId].offsets);
+                return acc;
+              }, {} as Record<string, Params>);
+            }
+            const preset = presetManager.get('color', name);
+            if (preset) {
+              colorPalette = preset;
+            }
+          }
+
+          if (category === 'visualizer' || category === 'speed') {
+            const patch = presetManager.computeHomePatch(category, name, toMinimalSnapshot(home), advanced);
+            if (patch) {
+              home = { ...home, ...patch };
+              sections = Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+                acc[sectionId] = deriveParams(home, SECTION_CONFIGS[sectionId].offsets);
+                return acc;
+              }, {} as Record<string, Params>);
+            }
+          }
+
+          return {
+            ...state,
+            home,
+            sections,
+            designSystem: {
+              ...state.designSystem,
+              selections,
+              advanced,
+              reactivitySettings,
+              colorPalette,
+              lastInteraction: { type: 'hover', at: timestamp },
+            },
+          };
+        });
+      },
+
+      SET_ADVANCED_TUNING: (key: keyof DesignSystemAdvancedTuning, value: number) => {
+        set((state) => ({
+          ...state,
+          designSystem: {
+            ...state.designSystem,
+            advanced: {
+              ...state.designSystem.advanced,
+              [key]: value,
+            },
+          },
+        }));
+      },
+
+      CREATE_CUSTOM_PRESET: (name: string, patch: ParameterPatch) => {
+        presetManager.registerCustomPreset(name, patch);
+        set((state) => ({
+          ...state,
+          designSystem: {
+            ...state.designSystem,
+            customPresets: { ...state.designSystem.customPresets, [name]: patch },
+          },
+        }));
+      },
+
+      RESET_SECTION_VISUAL_STATE: (sectionId?: string) => {
+        set((state) => {
+          const ids = sectionId ? [sectionId] : Object.keys(SECTION_CONFIGS);
+          const resetStates = resetSectionVisualStates(state.designSystem.sectionStates, ids);
+          return {
+            ...state,
+            designSystem: {
+              ...state.designSystem,
+              sectionStates: resetStates,
+            },
+          };
+        });
       },
     },
   }))


### PR DESCRIPTION
## Summary
- rebuild the homepage around an avant-garde hero, featured orbit carousel, and category-driven editorial sequences powered by the content API
- introduce reactive background, floating navigation, and immersive transmission panel flourishes for the blog experience
- add marquee animation keyframes to support looping manifesto copy in the dispatch section

## Testing
- `npm run type-check` *(fails: legacy specs in tests-backup rely on DOM globals and downlevel iteration flags)*
- `npm run lint` *(not run: command triggers interactive Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d35772d62483299ed6c6c0e701e5aa