### PR TITLE
Expand holographic system with layered accent choreography

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,313 +1,921 @@
-/**
- * VIB3CODE-0 Holographic AI Blog
- * 
- * Professional AI blog with subtle holographic effects
- * Clean, readable layout focused on content
- */
-
 'use client';
 
-import { useEffect, useState } from 'react';
-import { BlogPost, contentCategories } from '@/lib/blog-config';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Canvas } from '@react-three/fiber';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { BlogPost } from '@/lib/blog-config';
+import { contentCategories } from '@/lib/blog-config';
+import {
+  SECTION_CONFIGS,
+  useEvents,
+  useHomeParams,
+  useSectionParams,
+} from '@/lib/store';
+import type { VIB3GeometryParams } from '@/lib/vib34d-geometries';
 
-interface BlogSection {
-  id: string;
+const ParameterPanel = dynamic(() => import('@/components/ui/ParameterPanel'), {
+  ssr: false,
+  loading: () => null,
+});
+
+const VIB3Engine = dynamic(() => import('@/components/engines/VIB3Engine'), {
+  ssr: false,
+});
+
+type SectionId = keyof typeof SECTION_CONFIGS;
+
+interface AvantSection {
+  id: SectionId;
   title: string;
   subtitle: string;
-  content: string;
-  posts?: BlogPost[];
-  theme?: typeof contentCategories[keyof typeof contentCategories]['holographicTheme'];
+  description: string;
+  narrative: string;
+  posts: BlogPost[];
+  theme: typeof contentCategories[keyof typeof contentCategories]['holographicTheme'] | {
+    hue: number;
+    density: number;
+    intensity: number;
+    theme: string;
+    primaryColor: string;
+  };
 }
 
-// Simple holographic background effect (no complex visualizers)
-function HolographicBackground() {
+const heroStatements = [
+  'Cascading intelligence across crystalline dimensions.',
+  'Editorial choreography for synthetic cognition.',
+  'Research fragments refracted through hypercolor lattices.',
+  'Strategic futures encoded in harmonic phase space.',
+];
+
+const sectionNarratives: Record<SectionId, string> = {
+  home: 'Command center for the hyperjournal — every transmission tuned to the geometry of insight.',
+  'ai-news': 'Intercepted lab signals, translated into luminous bulletins and orbital briefings.',
+  'vibe-coding': 'Algorithmic improvisations rendered as tactile, playful instrument panels.',
+  'info-theory': 'Mathematical reveries about entropy, bandwidth, and elegant proof structures.',
+  philosophy: 'Speculative ethics and sentient aesthetics, rendered as soft quantum corridors.',
+};
+
+const geometryMap: Record<SectionId, number> = {
+  home: 1,
+  'ai-news': 3,
+  'vibe-coding': 5,
+  'info-theory': 2,
+  philosophy: 6,
+};
+
+const heroTheme = {
+  hue: 0.58,
+  density: 0.52,
+  intensity: 0.45,
+  theme: 'origin-gate',
+  primaryColor: '#22d3ee',
+};
+
+function formatLabel(label: string): string {
+  return label
+    .split('_')
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+    .join(' ');
+}
+
+function buildPlaceholderPosts(
+  category: keyof typeof contentCategories,
+  count = 3,
+): BlogPost[] {
+  const base = contentCategories[category];
+  const now = Date.now();
+  return Array.from({ length: count }).map((_, index) => ({
+    id: `placeholder-${category}-${index}`,
+    title: `${base.name.split(' ')[0]} Signal ${index + 1}`,
+    slug: `${category}-signal-${index + 1}`,
+    excerpt: `${base.description} — speculative transmission ${index + 1} exploring future scenarios and design praxis.`,
+    content: `# ${base.name} Transmission\n\nSynthesized narrative for prototype presentation.`,
+    author: {
+      name: 'VIB3CODE Collective',
+      avatar: '/avatars/vib3code.png',
+    },
+    publishedAt: new Date(now - index * 86400000),
+    updatedAt: new Date(now - index * 86400000),
+    tags: [base.name.split(' ')[0], 'VIB3CODE'],
+    category,
+    readingTime: 6 + index,
+    seo: {
+      metaTitle: `${base.name} Signal ${index + 1}`,
+      metaDescription: `${base.description} avant-garde digest.`,
+    },
+    holographicParams: base.holographicTheme,
+  }));
+}
+
+function useResolvedParams(sectionId: SectionId) {
+  const homeParams = useHomeParams();
+  const sectionParams = useSectionParams(sectionId);
+  return sectionParams || homeParams;
+}
+function AvantGardeBackground({
+  activeSection,
+  sections,
+}: {
+  activeSection: SectionId;
+  sections: AvantSection[];
+}) {
+  const homeParams = useHomeParams();
+  const sectionParams = useSectionParams(activeSection);
+  const resolved = sectionParams || homeParams;
+
+  const geometryIndex = geometryMap[activeSection] ?? 1;
+  const highlightGeometry = (geometryIndex + 2) % 8;
+  const accentGeometry = (geometryIndex + 5) % 8;
+  const shadowGeometry = (geometryIndex + 4) % 8;
+  const backgroundGeometry = (geometryIndex + 6) % 8;
+
+  const foundationParams: VIB3GeometryParams = useMemo(
+    () => ({
+      geometry: geometryIndex,
+      morph: resolved.morph,
+      chaos: Math.min(1, resolved.chaos * 0.9 + 0.02),
+      density: Math.min(1, resolved.density * 0.92 + 0.03),
+      hue: resolved.hue,
+      noiseFreq: resolved.noiseFreq,
+      dispAmp: resolved.dispAmp,
+      timeScale: resolved.timeScale,
+      beatPhase: resolved.beatPhase,
+    }),
+    [
+      geometryIndex,
+      resolved.morph,
+      resolved.chaos,
+      resolved.density,
+      resolved.hue,
+      resolved.noiseFreq,
+      resolved.dispAmp,
+      resolved.timeScale,
+      resolved.beatPhase,
+    ],
+  );
+
+  const highlightParams: VIB3GeometryParams = useMemo(
+    () => ({
+      geometry: highlightGeometry,
+      morph: Math.min(2, resolved.morph * 1.08 + 0.05),
+      chaos: Math.min(1, resolved.chaos * 1.25 + 0.05),
+      density: Math.min(1, resolved.density * 1.05 + 0.04),
+      hue: (resolved.hue + 0.14) % 1,
+      noiseFreq: resolved.noiseFreq * 1.1,
+      dispAmp: resolved.dispAmp * 1.1,
+      timeScale: resolved.timeScale * 1.15,
+      beatPhase: resolved.beatPhase,
+    }),
+    [
+      highlightGeometry,
+      resolved.morph,
+      resolved.chaos,
+      resolved.density,
+      resolved.hue,
+      resolved.noiseFreq,
+      resolved.dispAmp,
+      resolved.timeScale,
+      resolved.beatPhase,
+    ],
+  );
+
+  const accentParams: VIB3GeometryParams = useMemo(
+    () => ({
+      geometry: accentGeometry,
+      morph: resolved.morph * 0.8,
+      chaos: resolved.chaos * 0.6,
+      density: resolved.density * 0.7,
+      hue: (resolved.hue + 0.32) % 1,
+      noiseFreq: resolved.noiseFreq * 0.85,
+      dispAmp: resolved.dispAmp * 0.7,
+      timeScale: resolved.timeScale * 0.75,
+      beatPhase: resolved.beatPhase,
+    }),
+    [
+      accentGeometry,
+      resolved.morph,
+      resolved.chaos,
+      resolved.density,
+      resolved.hue,
+      resolved.noiseFreq,
+      resolved.dispAmp,
+      resolved.timeScale,
+      resolved.beatPhase,
+    ],
+  );
+
+  const shadowParams: VIB3GeometryParams = useMemo(
+    () => ({
+      geometry: shadowGeometry,
+      morph: resolved.morph * 0.95,
+      chaos: Math.min(1, resolved.chaos * 1.15 + 0.04),
+      density: Math.min(1, resolved.density * 1.12 + 0.05),
+      hue: (resolved.hue + 0.45) % 1,
+      noiseFreq: resolved.noiseFreq * 1.05,
+      dispAmp: resolved.dispAmp * 1.18,
+      timeScale: resolved.timeScale * 0.9,
+      beatPhase: resolved.beatPhase,
+    }),
+    [
+      shadowGeometry,
+      resolved.morph,
+      resolved.chaos,
+      resolved.density,
+      resolved.hue,
+      resolved.noiseFreq,
+      resolved.dispAmp,
+      resolved.timeScale,
+      resolved.beatPhase,
+    ],
+  );
+
+  const backgroundParams: VIB3GeometryParams = useMemo(
+    () => ({
+      geometry: backgroundGeometry,
+      morph: resolved.morph * 0.6,
+      chaos: resolved.chaos * 0.45 + 0.02,
+      density: resolved.density * 0.5 + 0.08,
+      hue: (resolved.hue + 0.08) % 1,
+      noiseFreq: resolved.noiseFreq * 0.75,
+      dispAmp: resolved.dispAmp * 0.62,
+      timeScale: resolved.timeScale * 0.58,
+      beatPhase: resolved.beatPhase,
+    }),
+    [
+      backgroundGeometry,
+      resolved.morph,
+      resolved.chaos,
+      resolved.density,
+      resolved.hue,
+      resolved.noiseFreq,
+      resolved.dispAmp,
+      resolved.timeScale,
+      resolved.beatPhase,
+    ],
+  );
+
+  const activeTheme = sections.find((section) => section.id === activeSection)?.theme;
+  const accentColor = activeTheme?.primaryColor ?? '#22d3ee';
+
   return (
-    <div className="fixed inset-0 z-0 pointer-events-none">
-      <div className="absolute inset-0 bg-gradient-to-br from-black via-slate-900 to-black" />
-      <div className="absolute inset-0 bg-gradient-to-t from-transparent via-cyan-500/5 to-transparent animate-pulse" />
-      <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-cyan-500/10 rounded-full blur-3xl animate-pulse" />
-      <div className="absolute bottom-1/4 right-1/4 w-64 h-64 bg-purple-500/10 rounded-full blur-2xl animate-pulse" style={{ animationDelay: '1s' }} />
+    <div className="fixed inset-0 -z-20 pointer-events-none overflow-hidden">
+      <div className="absolute inset-0 opacity-30 mix-blend-screen">
+        <Canvas className="w-full h-full" camera={{ position: [0, 0, 8.5], fov: 60 }}>
+          <Suspense fallback={null}>
+            <VIB3Engine
+              sectionId={activeSection}
+              layerType="background"
+              params={backgroundParams}
+              opacity={0.28}
+              pointSize={1.2}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+
+      <div className="absolute inset-0 opacity-90 mix-blend-screen">
+        <Canvas
+          className="w-full h-full"
+          camera={{ position: [0, 0, 6], fov: 45 }}
+        >
+          <color attach="background" args={['#040510']} />
+          <Suspense fallback={null}>
+            <VIB3Engine
+              sectionId={activeSection}
+              layerType="content"
+              params={foundationParams}
+              opacity={0.9}
+              pointSize={2.2}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+
+      <div className="absolute inset-0 mix-blend-multiply opacity-5">
+        <Canvas className="w-full h-full" camera={{ position: [0, 0, 6.5], fov: 48 }}>
+          <Suspense fallback={null}>
+            <VIB3Engine
+              sectionId={activeSection}
+              layerType="shadow"
+              params={shadowParams}
+              opacity={0.32}
+              pointSize={2.4}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+
+      <div className="absolute inset-0 mix-blend-plus-lighter opacity-65">
+        <Canvas
+          className="w-full h-full"
+          camera={{ position: [0, 0, 7], fov: 52 }}
+        >
+          <Suspense fallback={null}>
+            <VIB3Engine
+              sectionId={activeSection}
+              layerType="highlight"
+              params={highlightParams}
+              opacity={0.55}
+              pointSize={2.8}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+
+      <div className="absolute inset-0 mix-blend-screen opacity-45">
+        <Canvas
+          className="w-full h-full"
+          camera={{ position: [0, 0, 5.5], fov: 50 }}
+        >
+          <Suspense fallback={null}>
+            <VIB3Engine
+              sectionId={activeSection}
+              layerType="accent"
+              params={accentParams}
+              opacity={0.38}
+              pointSize={1.6}
+            />
+          </Suspense>
+        </Canvas>
+      </div>
+
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            `radial-gradient(circle at 20% 20%, ${accentColor}1a, transparent 55%),` +
+            `radial-gradient(circle at 80% 70%, ${accentColor}12, transparent 60%)`,
+        }}
+      />
+
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,#ffffff0d,transparent_65%)]" />
     </div>
   );
 }
 
-// Article card component
-function ArticleCard({ post }: { post: BlogPost }) {
+function HeroSection({
+  section,
+  onExplore,
+}: {
+  section: AvantSection;
+  onExplore: () => void;
+}) {
+  const events = useEvents();
+  const params = useHomeParams();
+  const [lineIndex, setLineIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setLineIndex((prev) => (prev + 1) % heroStatements.length);
+    }, 4200);
+    return () => clearInterval(interval);
+  }, []);
+
   return (
-    <article className="bg-black/40 backdrop-blur-sm rounded-lg border border-cyan-500/20 p-6 hover:border-cyan-400/40 transition-all duration-300 group cursor-pointer">
-      <div className="flex justify-between items-start mb-3">
-        <h3 className="text-xl font-bold text-white group-hover:text-cyan-300 transition-colors">
-          {post.title}
-        </h3>
-        <span className="text-sm text-gray-400 whitespace-nowrap ml-4">
-          {post.readingTime} min read
-        </span>
-      </div>
-      <p className="text-gray-300 mb-4 leading-relaxed">
-        {post.excerpt}
-      </p>
-      <div className="flex justify-between items-center mb-4">
-        <time className="text-sm text-cyan-400">
-          {post.publishedAt.toLocaleDateString('en-US', { 
-            year: 'numeric', 
-            month: 'long', 
-            day: 'numeric' 
-          })}
-        </time>
-        <div className="flex items-center space-x-2">
-          {post.author.avatar && (
-            <img 
-              src={post.author.avatar} 
-              alt={post.author.name}
-              className="w-6 h-6 rounded-full"
-            />
-          )}
-          <span className="text-sm text-gray-400">{post.author.name}</span>
-        </div>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {post.tags.slice(0, 3).map((tag) => (
-          <span 
-            key={tag}
-            className="px-2 py-1 bg-cyan-500/20 text-cyan-300 text-xs rounded-full"
-          >
-            {tag}
+    <section
+      id={`section-${section.id}`}
+      data-section-id={section.id}
+      className="snap-start min-h-screen relative flex items-center py-32"
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'linear-gradient(135deg, rgba(4,7,18,0.65) 0%, rgba(9,15,32,0.1) 55%, rgba(4,7,18,0.65) 100%)',
+        }}
+      />
+
+      <div className="relative z-10 w-full max-w-7xl mx-auto px-6 lg:px-12 grid gap-16 lg:grid-cols-[1.2fr_0.8fr] items-center">
+        <motion.div
+          initial={{ opacity: 0, y: 80 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1.1, ease: 'easeOut' }}
+          className="space-y-8"
+        >
+          <span className="inline-flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-cyan-200/70">
+            <span className="h-0.5 w-10 bg-cyan-200/60" />
+            Hyperjournal Signal
           </span>
-        ))}
-      </div>
-    </article>
-  );
-}
 
-// Section component
-function BlogSection({ section, isHero = false }: { section: BlogSection, isHero?: boolean }) {
-  if (isHero) {
-    return (
-      <section className="min-h-screen flex items-center justify-center relative z-10">
-        <div className="text-center max-w-4xl mx-auto px-6">
-          <h1 className="text-8xl font-black mb-6 bg-gradient-to-r from-cyan-400 via-purple-400 to-cyan-400 bg-clip-text text-transparent animate-pulse">
-            {section.title}
+          <h1 className="text-6xl md:text-7xl xl:text-8xl font-black leading-[0.95] text-white">
+            VIB3CODE <span className="text-cyan-300">HyperJournal</span>
           </h1>
-          <h2 className="text-3xl font-light text-gray-200 mb-8">
-            {section.subtitle}
-          </h2>
-          <p className="text-xl text-gray-300 leading-relaxed max-w-2xl mx-auto">
-            {section.content}
-          </p>
-          <div className="mt-12">
-            <button 
-              onClick={() => document.getElementById('ai-news')?.scrollIntoView({ behavior: 'smooth' })}
-              className="bg-gradient-to-r from-cyan-600 to-purple-600 text-white px-8 py-4 rounded-lg font-medium hover:from-cyan-500 hover:to-purple-500 transition-all duration-300 transform hover:scale-105"
-            >
-              Explore Articles
-            </button>
+
+          <div className="h-16 relative">
+            <AnimatePresence mode="wait">
+              <motion.p
+                key={lineIndex}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.8, ease: 'easeInOut' }}
+                className="text-lg md:text-xl text-cyan-100/80 max-w-2xl"
+              >
+                {heroStatements[lineIndex]}
+              </motion.p>
+            </AnimatePresence>
           </div>
-        </div>
-      </section>
-    );
-  }
 
-  const themeColors = section.theme ? {
-    from: section.theme.primaryColor + '40',
-    to: section.theme.primaryColor + '60'
-  } : { from: 'cyan-400', to: 'purple-400' };
-
-  return (
-    <section id={section.id} className="min-h-screen py-20 relative z-10">
-      <div className="max-w-7xl mx-auto px-6">
-        <div className="text-center mb-16">
-          <h2 className={`text-6xl font-black mb-4 bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent`}>
-            {section.title}
-          </h2>
-          <h3 className="text-2xl font-light text-gray-300 mb-6">
-            {section.subtitle}
-          </h3>
-          <p className="text-lg text-gray-400 max-w-3xl mx-auto leading-relaxed">
-            {section.content}
+          <p className="text-base md:text-lg text-cyan-100/70 max-w-3xl">
+            {section.narrative}
           </p>
-        </div>
 
-        {section.posts && section.posts.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {section.posts.map((post) => (
-              <ArticleCard key={post.id} post={post} />
+          <div className="flex flex-wrap gap-6">
+            {[
+              { label: 'Hue', value: `${Math.round(params.hue * 360)}°` },
+              { label: 'Density', value: `${Math.round(params.density * 100)}%` },
+              { label: 'Morph', value: params.morph.toFixed(2) },
+              { label: 'Chaos', value: `${Math.round(params.chaos * 100)}%` },
+            ].map((metric) => (
+              <div
+                key={metric.label}
+                className="px-5 py-3 rounded-full bg-cyan-500/10 border border-cyan-500/30 text-sm font-mono text-cyan-200/80"
+              >
+                <span className="text-cyan-100/40 mr-3">{metric.label}</span>
+                {metric.value}
+              </div>
             ))}
           </div>
-        )}
 
-        {(!section.posts || section.posts.length === 0) && (
-          <div className="text-center py-12">
-            <div className="text-gray-400">Loading articles...</div>
+          <div className="flex items-center gap-6 pt-6">
+            <button
+              onClick={() => {
+                events.APPLY_CLICK_RESPONSE('home');
+                onExplore();
+              }}
+              onMouseEnter={() => events.HOVER_START('home')}
+              onMouseLeave={() => events.HOVER_END('home')}
+              className="px-8 py-4 rounded-full bg-gradient-to-r from-cyan-500 via-purple-500 to-cyan-400 text-white text-sm uppercase tracking-[0.3em] shadow-[0_0_40px_rgba(34,211,238,0.3)] transition-transform duration-500 hover:scale-105"
+            >
+              Enter Transmission Grid
+            </button>
+            <span className="text-xs text-cyan-100/50 uppercase tracking-[0.4em]">
+              Scroll • Navigate • Interact
+            </span>
           </div>
-        )}
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 120 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 1.2, ease: 'easeOut', delay: 0.1 }}
+          className="relative"
+        >
+          <div className="absolute -inset-6 bg-cyan-500/10 blur-3xl" />
+          <div className="relative rounded-3xl border border-white/10 bg-black/40 backdrop-blur-2xl p-8 space-y-6">
+            <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-cyan-100/70">
+              <span>System Overview</span>
+              <span>VIB34D</span>
+            </div>
+
+            <div className="space-y-4 text-sm text-cyan-100/60">
+              <p>• Layered geometry engine orchestrated through preset choreography.</p>
+              <p>• Interaction multiplexing links hover, scroll, and beat-synced modulation.</p>
+              <p>• Editor-ready parameter banks for designing entire realities instantly.</p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 text-xs text-cyan-100/60">
+              <div className="p-4 rounded-xl bg-white/5 border border-white/10">
+                <div className="text-[10px] uppercase tracking-[0.4em] text-cyan-100/40 mb-2">Incoming Transition</div>
+                <div className="text-sm text-white">{formatLabel(SECTION_CONFIGS.home.transitionIn)}</div>
+              </div>
+              <div className="p-4 rounded-xl bg-white/5 border border-white/10">
+                <div className="text-[10px] uppercase tracking-[0.4em] text-cyan-100/40 mb-2">Outgoing Transition</div>
+                <div className="text-sm text-white">{formatLabel(SECTION_CONFIGS.home.transitionOut)}</div>
+              </div>
+            </div>
+
+            <div className="pt-4 border-t border-white/10 text-xs uppercase tracking-[0.3em] text-cyan-100/40">
+              Fully synchronized with the VIB34D preset banks and editor interface.
+            </div>
+          </div>
+        </motion.div>
       </div>
     </section>
   );
 }
-
-// Navigation component
-function Navigation({ sections }: { sections: BlogSection[] }) {
-  const [activeSection, setActiveSection] = useState('hero');
-
-  useEffect(() => {
-    if (sections.length === 0) return;
-    
-    const handleScroll = () => {
-      const scrollPosition = window.scrollY + 200;
-      
-      for (const section of sections) {
-        const element = document.getElementById(section.id);
-        if (element && scrollPosition >= element.offsetTop && scrollPosition < element.offsetTop + element.offsetHeight) {
-          setActiveSection(section.id);
-          break;
-        }
-      }
-    };
-
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [sections]);
+function AvantPostCard({
+  post,
+  sectionId,
+  accentColor,
+}: {
+  post: BlogPost;
+  sectionId: SectionId;
+  accentColor: string;
+}) {
+  const events = useEvents();
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-sm border-b border-cyan-500/20">
-      <div className="max-w-7xl mx-auto px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div className="text-2xl font-black text-cyan-400">
-            VIB3CODE
-          </div>
-          
-          <div className="hidden md:flex space-x-8">
-            {sections.slice(1).map((section) => (
-              <button
-                key={section.id}
-                onClick={() => document.getElementById(section.id)?.scrollIntoView({ behavior: 'smooth' })}
-                className={`text-sm font-medium transition-colors ${
-                  activeSection === section.id 
-                    ? 'text-cyan-400' 
-                    : 'text-gray-400 hover:text-cyan-300'
-                }`}
-              >
-                {section.title}
-              </button>
-            ))}
-          </div>
+    <motion.article
+      initial={{ opacity: 0, y: 50 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.8, ease: 'easeOut' }}
+      whileHover={{ scale: 1.02, rotateX: 4, rotateY: -3 }}
+      className="group relative overflow-hidden rounded-3xl border border-white/10 bg-black/40 backdrop-blur-2xl p-6 cursor-pointer"
+      onHoverStart={() => events.HOVER_START(sectionId)}
+      onHoverEnd={() => events.HOVER_END(sectionId)}
+      onClick={() => events.APPLY_CLICK_RESPONSE(sectionId)}
+    >
+      <div
+        className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+        style={{
+          background: `radial-gradient(circle at 20% 20%, ${accentColor}33, transparent 60%)`,
+        }}
+      />
+      <div className="absolute -inset-24 bg-[conic-gradient(from_90deg_at_50%_50%,transparent_0deg,${accentColor}22_120deg,transparent_300deg)] opacity-0 group-hover:opacity-100 transition-opacity duration-700" />
 
-          <div className="flex items-center space-x-4">
-            <button className="text-gray-400 hover:text-cyan-400 transition-colors">
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
-              </svg>
-            </button>
-          </div>
+      <div className="relative z-10 space-y-4">
+        <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-cyan-100/60">
+          <span>{post.category.replace('-', ' ')}</span>
+          <span>{post.readingTime} min</span>
+        </div>
+        <h3 className="text-2xl font-bold text-white leading-tight">
+          {post.title}
+        </h3>
+        <p className="text-sm text-cyan-100/70 leading-relaxed">
+          {post.excerpt}
+        </p>
+
+        <div className="flex items-center justify-between text-xs text-cyan-100/60">
+          <span>{post.author.name}</span>
+          <time>
+            {post.publishedAt.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })}
+          </time>
+        </div>
+
+        <div className="flex flex-wrap gap-2 pt-2">
+          {post.tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="px-3 py-1 rounded-full bg-white/5 border border-white/10 text-[10px] uppercase tracking-[0.3em] text-cyan-100/60"
+            >
+              {tag}
+            </span>
+          ))}
         </div>
       </div>
-    </nav>
+    </motion.article>
   );
 }
 
-// Admin link (hidden, accessible via URL)
-function AdminLink() {
+function AvantSectionPanel({
+  section,
+  index,
+}: {
+  section: AvantSection;
+  index: number;
+}) {
+  const params = useResolvedParams(section.id);
+  const accentColor = section.theme?.primaryColor ?? '#22d3ee';
+
+  const metrics = [
+    { label: 'Hue', value: `${Math.round((params.hue % 1) * 360)}°` },
+    { label: 'Density', value: `${Math.round(params.density * 100)}%` },
+    { label: 'Morph', value: params.morph.toFixed(2) },
+    { label: 'Chaos', value: `${Math.round(params.chaos * 100)}%` },
+  ];
+
+  const transitions = SECTION_CONFIGS[section.id];
+
   return (
-    <div className="fixed bottom-4 right-4 z-50">
-      <button
-        onClick={() => window.location.href = '/admin'}
-        className="opacity-20 hover:opacity-100 transition-opacity duration-300 text-xs text-gray-500 hover:text-cyan-400"
-      >
-        Admin
-      </button>
+    <motion.section
+      id={`section-${section.id}`}
+      data-section-id={section.id}
+      className="snap-start min-h-screen relative flex items-center py-28"
+      initial={{ opacity: 0, y: 120 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.35 }}
+      transition={{ duration: 1, ease: 'easeOut', delay: index * 0.05 }}
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background:
+            'linear-gradient(135deg, rgba(6,10,20,0.65) 0%, rgba(8,12,25,0.35) 50%, rgba(6,10,20,0.7) 100%)',
+        }}
+      />
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            `radial-gradient(circle at ${20 + index * 12}% 20%, ${accentColor}1b, transparent 55%),` +
+            `radial-gradient(circle at ${70 - index * 8}% 75%, ${accentColor}12, transparent 65%)`,
+        }}
+      />
+
+      <div className="relative z-10 w-full max-w-7xl mx-auto px-6 lg:px-12 grid gap-16 lg:grid-cols-[0.95fr_1.05fr] items-start">
+        <div className="space-y-10">
+          <div className="space-y-4">
+            <span className="inline-flex items-center gap-3 text-[10px] uppercase tracking-[0.4em] text-cyan-100/50">
+              <span className="h-0.5 w-8 bg-cyan-100/40" />
+              {section.subtitle}
+            </span>
+            <h2 className="text-5xl md:text-6xl font-bold text-white leading-[1.05]">
+              {section.title}
+            </h2>
+            <p className="text-base md:text-lg text-cyan-100/75 max-w-xl">
+              {section.description}
+            </p>
+            <p className="text-sm uppercase tracking-[0.35em] text-cyan-100/40">
+              {section.narrative}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            {metrics.map((metric) => (
+              <div
+                key={metric.label}
+                className="rounded-2xl border border-white/10 bg-black/40 backdrop-blur-xl px-6 py-5 text-sm text-cyan-100/70"
+              >
+                <div className="text-[10px] uppercase tracking-[0.4em] text-cyan-100/40 mb-2">
+                  {metric.label}
+                </div>
+                <div className="text-xl font-semibold text-white">{metric.value}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 text-xs text-cyan-100/60">
+            <div className="p-4 rounded-xl bg-white/5 border border-white/10">
+              <div className="text-[10px] uppercase tracking-[0.4em] text-cyan-100/35 mb-2">Transition In</div>
+              <div className="text-sm text-white">{formatLabel(transitions.transitionIn)}</div>
+            </div>
+            <div className="p-4 rounded-xl bg-white/5 border border-white/10">
+              <div className="text-[10px] uppercase tracking-[0.4em] text-cyan-100/35 mb-2">Transition Out</div>
+              <div className="text-sm text-white">{formatLabel(transitions.transitionOut)}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {section.posts.map((post) => (
+            <AvantPostCard
+              key={post.id}
+              post={post}
+              sectionId={section.id}
+              accentColor={accentColor}
+            />
+          ))}
+        </div>
+      </div>
+    </motion.section>
+  );
+}
+
+function SectionNavigation({
+  sections,
+  currentSection,
+}: {
+  sections: AvantSection[];
+  currentSection: SectionId;
+}) {
+  const events = useEvents();
+
+  return (
+    <div className="hidden xl:flex flex-col gap-4 fixed top-1/2 right-12 -translate-y-1/2 z-40">
+      {sections.map((section) => (
+        <button
+          key={section.id}
+          onMouseEnter={() => events.HOVER_START(section.id)}
+          onMouseLeave={() => events.HOVER_END(section.id)}
+          onClick={() => {
+            events.APPLY_CLICK_RESPONSE(section.id);
+            document.getElementById(`section-${section.id}`)?.scrollIntoView({ behavior: 'smooth' });
+          }}
+          className={`group relative flex items-center gap-3 text-xs uppercase tracking-[0.35em] transition-all duration-500 ${
+            currentSection === section.id
+              ? 'text-white'
+              : 'text-cyan-100/40 hover:text-white'
+          }`}
+        >
+          <span
+            className={`h-px w-12 transition-all duration-500 ${
+              currentSection === section.id ? 'bg-white w-16' : 'bg-cyan-100/40 group-hover:bg-white'
+            }`}
+          />
+          {section.title}
+        </button>
+      ))}
     </div>
   );
 }
 
-export default function HomePage() {
-  const [sections, setSections] = useState<BlogSection[]>([]);
+function SectionTelemetry({ currentSection }: { currentSection: SectionId }) {
+  const config = SECTION_CONFIGS[currentSection];
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40">
+      <div className="flex items-center gap-6 rounded-full border border-white/10 bg-black/40 backdrop-blur-2xl px-6 py-3 text-[10px] uppercase tracking-[0.4em] text-cyan-100/50">
+        <span className="flex items-center gap-2 text-white">
+          <span className="h-2 w-2 rounded-full bg-cyan-400 animate-pulse" />
+          {config.name}
+        </span>
+        <span>In · {formatLabel(config.transitionIn)}</span>
+        <span>Out · {formatLabel(config.transitionOut)}</span>
+        <span>Beat · {config.id === 'home' ? 'Origin' : 'Sustained'}</span>
+      </div>
+    </div>
+  );
+}
+export default function AvantGardeBlogPage() {
+  const events = useEvents();
+  const homeParams = useHomeParams();
+  const [sections, setSections] = useState<AvantSection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [currentSection, setCurrentSection] = useState<SectionId>('home');
 
   useEffect(() => {
+    let cancelled = false;
+
     const loadContent = async () => {
+      setLoading(true);
+      const heroSection: AvantSection = {
+        id: 'home',
+        title: 'Singular Foresight',
+        subtitle: 'Holographic Dispatch',
+        description: 'An avant-garde research magazine where transitions, presets, and ideas align in luminous synchrony.',
+        narrative: sectionNarratives.home,
+        posts: [],
+        theme: heroTheme,
+      };
+
       try {
-        // Hero section (static content)
-        const heroSection: BlogSection = {
-          id: 'hero',
-          title: 'VIB3CODE',
-          subtitle: 'AI Research & Development Blog',
-          content: 'Exploring the frontiers of artificial intelligence, machine learning, and computational creativity.'
-        };
-
-        // Load content for each category using static content
-        const categoryKeys = Object.keys(contentCategories) as (keyof typeof contentCategories)[];
-        const contentSections: BlogSection[] = [];
-
-        // Create static content provider
         const { contentAPI } = await import('@/lib/content-api');
-        
-        for (const categoryKey of categoryKeys) {
-          const category = contentCategories[categoryKey];
-          
-          try {
-            // Get posts for this category from static provider
-            const result = await contentAPI.getPostsByCategory(categoryKey);
-            
-            contentSections.push({
-              id: categoryKey,
-              title: category.name.split(' &')[0], // Shorten for display
-              subtitle: category.name,
-              content: category.description,
-              posts: result.posts || [],
-              theme: category.holographicTheme
-            });
-          } catch (error) {
-            console.error(`Failed to load ${categoryKey} posts:`, error);
-            // Add section without posts
-            contentSections.push({
-              id: categoryKey,
-              title: category.name.split(' &')[0],
-              subtitle: category.name,
-              content: category.description,
-              posts: [],
-              theme: category.holographicTheme
-            });
-          }
-        }
+        const categoryKeys = Object.keys(contentCategories) as Array<keyof typeof contentCategories>;
 
-        setSections([heroSection, ...contentSections]);
-        setLoading(false);
+        const contentSections = await Promise.all(
+          categoryKeys.map(async (categoryKey) => {
+            try {
+              const result = await contentAPI.getPostsByCategory(categoryKey);
+              const posts = result.posts.length ? result.posts : buildPlaceholderPosts(categoryKey);
+
+              return {
+                id: categoryKey as SectionId,
+                title: contentCategories[categoryKey].name,
+                subtitle: contentCategories[categoryKey].name,
+                description: contentCategories[categoryKey].description,
+                narrative: sectionNarratives[categoryKey as SectionId],
+                posts,
+                theme: result.theme,
+              } satisfies AvantSection;
+            } catch (error) {
+              console.warn('Failed to load posts for', categoryKey, error);
+              return {
+                id: categoryKey as SectionId,
+                title: contentCategories[categoryKey].name,
+                subtitle: contentCategories[categoryKey].name,
+                description: contentCategories[categoryKey].description,
+                narrative: sectionNarratives[categoryKey as SectionId],
+                posts: buildPlaceholderPosts(categoryKey),
+                theme: contentCategories[categoryKey].holographicTheme,
+              } satisfies AvantSection;
+            }
+          }),
+        );
+
+        if (!cancelled) {
+          setSections([heroSection, ...contentSections]);
+          setLoading(false);
+        }
       } catch (error) {
-        console.error('Failed to load content:', error);
-        setLoading(false);
+        console.error('Failed to initialize sections', error);
+        if (!cancelled) {
+          const fallbackCategoryIds = ['ai-news', 'vibe-coding', 'info-theory', 'philosophy'] as const;
+          const fallbackSections: AvantSection[] = [
+            heroSection,
+            ...fallbackCategoryIds.map((categoryId) => ({
+              id: categoryId,
+              title: contentCategories[categoryId].name,
+              subtitle: contentCategories[categoryId].name,
+              description: contentCategories[categoryId].description,
+              narrative: sectionNarratives[categoryId],
+              posts: buildPlaceholderPosts(categoryId),
+              theme: contentCategories[categoryId].holographicTheme,
+            })),
+          ];
+          setSections(fallbackSections);
+          setLoading(false);
+        }
       }
     };
 
     loadContent();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute('data-section-id') as SectionId | null;
+            if (id) {
+              setCurrentSection(id);
+            }
+          }
+        });
+      },
+      { threshold: 0.5 },
+    );
+
+    sections.forEach((section) => {
+      const element = document.getElementById(`section-${section.id}`);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => observer.disconnect();
+  }, [sections]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(function loop() {
+      events.TICK(0.016);
+      requestAnimationFrame(loop);
+    });
+    const beat = setInterval(() => events.CLOCK_BEAT(), 2000);
+    return () => {
+      cancelAnimationFrame(frame);
+      clearInterval(beat);
+    };
+  }, [events]);
+
+  useEffect(() => {
+    const handleWheel = (event: WheelEvent) => {
+      const direction = event.deltaY > 0 ? 'down' : 'up';
+      const velocity = Math.min(1, Math.abs(event.deltaY) / 900 + 0.05);
+      events.APPLY_SCROLL_RESPONSE(direction, velocity);
+    };
+    window.addEventListener('wheel', handleWheel, { passive: true });
+    return () => window.removeEventListener('wheel', handleWheel);
+  }, [events]);
+
+  useEffect(() => {
+    Object.entries(homeParams).forEach(([key, value]) => {
+      const cssName = `--param-${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
+      document.documentElement.style.setProperty(cssName, `${value}`);
+    });
+  }, [homeParams]);
+
+  useEffect(() => {
+    const focusIndex = sections.findIndex((section) => section.id === currentSection);
+    if (focusIndex >= 0) {
+      const progress = focusIndex / Math.max(1, sections.length - 1);
+      document.documentElement.style.setProperty('--focus-section', `'${currentSection}'`);
+      document.documentElement.style.setProperty('--scroll-progress', `${progress}`);
+      document.documentElement.style.setProperty('--bg-offset-x', `${(progress - 0.5) * 160}px`);
+      document.documentElement.style.setProperty('--bg-offset-y', `${(progress - 0.5) * 60}px`);
+      document.documentElement.style.setProperty('--bg-scale', `${1 + (progress - 0.5) * 0.08}`);
+      document.documentElement.style.setProperty('--bg-rotation', `${(progress - 0.5) * 16}deg`);
+    }
+    events.SET_FOCUS(currentSection);
+  }, [currentSection, sections, events]);
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-black text-white font-[family-name:var(--font-orbitron)] flex items-center justify-center">
-        <div className="text-center">
-          <div className="text-4xl font-bold text-cyan-400 mb-4 animate-pulse">VIB3CODE</div>
-          <div className="text-gray-400">Loading holographic blog...</div>
+      <div className="min-h-screen bg-black text-white flex items-center justify-center">
+        <div className="holographic-spinner">
+          <div className="spinner-ring" />
+          <div className="spinner-text">Calibrating holographic blog...</div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-black text-white font-[family-name:var(--font-orbitron)]">
-      <HolographicBackground />
-      <Navigation sections={sections} />
-      
-      {/* Hero Section */}
-      {sections.length > 0 && (
-        <BlogSection section={sections[0]} isHero={true} />
-      )}
-      
-      {/* Content Sections */}
-      {sections.slice(1).map((section) => (
-        <BlogSection key={section.id} section={section} />
-      ))}
+    <div className="relative min-h-screen bg-black text-white overflow-hidden">
+      <AvantGardeBackground activeSection={currentSection} sections={sections} />
+      <SectionNavigation sections={sections} currentSection={currentSection} />
 
-      <AdminLink />
+      <main className="relative z-10">
+        {sections.map((section, index) =>
+          section.id === 'home' ? (
+            <HeroSection
+              key={section.id}
+              section={section}
+              onExplore={() =>
+                document.getElementById('section-ai-news')?.scrollIntoView({ behavior: 'smooth' })
+              }
+            />
+          ) : (
+            <AvantSectionPanel key={section.id} section={section} index={index} />
+          ),
+        )}
+      </main>
+
+      <SectionTelemetry currentSection={currentSection} />
+
+      <Suspense fallback={null}>
+        <ParameterPanel />
+      </Suspense>
     </div>
   );
 }

--- a/lib/design-system/constants.ts
+++ b/lib/design-system/constants.ts
@@ -1,0 +1,244 @@
+import {
+  CardTransitionsDefinition,
+  HoverResponseDefinition,
+  ClickResponseDefinition,
+  TransitionCoordinationDefinition,
+} from './types';
+
+export const UNIVERSAL_HOVER_RESPONSE: HoverResponseDefinition = {
+  target: {
+    gridDensity: 'increase_2x',
+    colorIntensity: 'increase_1.5x',
+    reactivity: 'increase_1.3x',
+    depth: 'lift_forward_10px',
+  },
+  others: {
+    gridDensity: 'decrease_0.5x',
+    colorIntensity: 'decrease_0.8x',
+    reactivity: 'decrease_0.7x',
+    depth: 'push_back_5px',
+  },
+  accent: {
+    target: {
+      gridDensity: 'increase_2.4x',
+      colorIntensity: 'increase_1.8x',
+      reactivity: 'increase_1.5x',
+      depth: 'lift_forward_18px',
+    },
+    others: {
+      gridDensity: 'decrease_0.6x',
+      colorIntensity: 'decrease_0.75x',
+      reactivity: 'decrease_0.65x',
+      depth: 'push_back_9px',
+    },
+  },
+  complementary: {
+    target: {
+      gridDensity: 'increase_1.7x',
+      colorIntensity: 'increase_1.4x',
+      reactivity: 'increase_1.25x',
+      depth: 'lift_forward_6px',
+    },
+    others: {
+      gridDensity: 'decrease_0.7x',
+      colorIntensity: 'decrease_0.85x',
+      reactivity: 'decrease_0.75x',
+      depth: 'push_back_4px',
+    },
+  },
+  transition: {
+    duration: '300ms',
+    easing: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+    stagger: '50ms',
+  },
+};
+
+export const UNIVERSAL_CLICK_RESPONSE: ClickResponseDefinition = {
+  primary: {
+    target: {
+      gridDensity: 'increase_1.3x',
+      colorIntensity: 'increase_1.4x',
+      reactivity: 'increase_1.35x',
+      depth: 'lift_forward_12px',
+    },
+    others: {
+      gridDensity: 'decrease_0.8x',
+      colorIntensity: 'decrease_0.85x',
+      reactivity: 'decrease_0.75x',
+      depth: 'push_back_6px',
+    },
+  },
+  immediate: {
+    colorInversion: 'full_spectrum',
+    variableInversion: {
+      speed: 'reverse_direction',
+      density: 'inverse_value',
+      intensity: 'flip_polarity',
+    },
+    rippleEffect: 'radial_burst',
+    sparkleGeneration: '8_particles',
+  },
+  duration: {
+    inversion: '2000ms',
+    decay: '500ms',
+    sparkles: '1500ms',
+  },
+  accent: {
+    target: {
+      gridDensity: 'increase_1.6x',
+      colorIntensity: 'increase_1.7x',
+      reactivity: 'increase_1.6x',
+      depth: 'lift_forward_20px',
+    },
+    others: {
+      gridDensity: 'decrease_0.7x',
+      colorIntensity: 'decrease_0.8x',
+      reactivity: 'decrease_0.7x',
+      depth: 'push_back_10px',
+    },
+    rippleEffect: 'accent_ring',
+    sparkleGeneration: '16_particles',
+    duration: '900ms',
+  },
+  complementary: {
+    target: {
+      gridDensity: 'increase_1.2x',
+      colorIntensity: 'increase_1.25x',
+      reactivity: 'increase_1.15x',
+      depth: 'lift_forward_8px',
+    },
+    others: {
+      gridDensity: 'decrease_0.85x',
+      colorIntensity: 'decrease_0.9x',
+      reactivity: 'decrease_0.85x',
+      depth: 'push_back_5px',
+    },
+    rippleEffect: 'complementary_wave',
+    sparkleGeneration: '10_particles',
+    duration: '700ms',
+  },
+};
+
+export const TRANSITION_COORDINATION: TransitionCoordinationDefinition = {
+  outgoing: {
+    phase1: 'density_collapse',
+    phase2: 'color_fade_to_black',
+    phase3: 'geometry_dissolve',
+    phase4: 'translucency_to_zero',
+    timing: {
+      phase1: '0ms-400ms',
+      phase2: '200ms-600ms',
+      phase3: '400ms-800ms',
+      phase4: '600ms-1000ms',
+    },
+  },
+  incoming: {
+    phase1: 'translucency_from_zero',
+    phase2: 'geometry_crystallize',
+    phase3: 'color_bloom',
+    phase4: 'density_expansion',
+    timing: {
+      phase1: '500ms-900ms',
+      phase2: '700ms-1100ms',
+      phase3: '900ms-1300ms',
+      phase4: '1100ms-1500ms',
+    },
+  },
+  accent: {
+    phase1: 'accent_flare_charge',
+    phase2: 'accent_wave_emit',
+    phase3: 'accent_glimmer_decay',
+    phase4: 'accent_harmonic_release',
+    timing: {
+      phase1: '300ms-600ms',
+      phase2: '600ms-900ms',
+      phase3: '900ms-1200ms',
+      phase4: '1200ms-1600ms',
+    },
+  },
+  complementary: {
+    phase1: 'complementary_swell',
+    phase2: 'complementary_lattice_shift',
+    phase3: 'complementary_color_echo',
+    phase4: 'complementary_depth_settle',
+    timing: {
+      phase1: '400ms-700ms',
+      phase2: '700ms-1000ms',
+      phase3: '1000ms-1400ms',
+      phase4: '1400ms-1800ms',
+    },
+  },
+  mathematical_relationship: {
+    density_conservation: 'outgoing_loss = incoming_gain',
+    color_harmonic: 'complementary_color_progression',
+    geometric_morphing: 'shared_mathematical_transform',
+  },
+};
+
+export const CARD_TRANSITIONS_STATES: CardTransitionsDefinition = {
+  emergence: {
+    from_background: {
+      translucency: '0 → 0.8',
+      depth: 'background_layer → foreground_layer',
+      scale: '0.8 → 1.0',
+      geometry_sync: 'background_visualizer_parameters',
+      duration: '1200ms',
+    },
+    from_center: {
+      scale: '0 → 1.0',
+      rotation: '360deg → 0deg',
+      blur: '20px → 0px',
+      emergence_point: 'screen_center',
+      duration: '800ms',
+    },
+  },
+  submersion: {
+    to_background: {
+      translucency: '0.8 → 0',
+      depth: 'foreground_layer → background_layer',
+      scale: '1.0 → 0.8',
+      geometry_sync: 'merge_with_background_visualizer',
+      duration: '1000ms',
+    },
+    to_center: {
+      scale: '1.0 → 0',
+      rotation: '0deg → 360deg',
+      blur: '0px → 20px',
+      convergence_point: 'screen_center',
+      duration: '600ms',
+    },
+  },
+  accent: {
+    halo_bloom: {
+      translucency: '0.3 → 0.9',
+      depth: 'mid_layer → highlight_layer',
+      scale: '1.0 → 1.15',
+      geometry_sync: 'accent_visualizer_phase_lock',
+      duration: '900ms',
+    },
+    flare_loop: {
+      rotation: '0deg → -180deg',
+      blur: '5px → 0px',
+      scale: '0.9 → 1.1',
+      emergence_point: 'perimeter_field',
+      duration: '750ms',
+    },
+  },
+  complementary: {
+    lattice_shear: {
+      translucency: '0.2 → 0.7',
+      depth: 'background_layer → mid_layer',
+      scale: '0.85 → 1.05',
+      geometry_sync: 'complementary_visualizer_blend',
+      duration: '800ms',
+    },
+    prism_slide: {
+      scale: '1.05 → 0.95',
+      rotation: '45deg → 0deg',
+      blur: '0px → 10px',
+      convergence_point: 'corner_nodes',
+      duration: '700ms',
+    },
+  },
+};
+

--- a/lib/design-system/content-integration.ts
+++ b/lib/design-system/content-integration.ts
@@ -1,0 +1,147 @@
+import {
+  ContentManagementDefinition,
+  ScrollableCardsDefinition,
+  VideoExpansionDefinition,
+} from './types';
+
+export const SCROLLABLE_CARDS_CONFIG: ScrollableCardsDefinition = {
+  grid_layout: {
+    columns: 'auto-fit(minmax(250px, 1fr))',
+    gap: '20px',
+    scroll_behavior: 'smooth',
+    scroll_snap: 'y_mandatory',
+    virtualization: 'enabled_for_performance',
+  },
+  scroll_interactions: {
+    visualizer_response: {
+      scroll_up: 'increase_grid_density',
+      scroll_down: 'decrease_grid_density',
+      scroll_velocity: 'affects_animation_speed',
+      scroll_momentum: 'creates_trailing_effects',
+    },
+    content_behavior: {
+      snap_points: 'every_3_items',
+      momentum_scrolling: 'ios_style',
+      edge_bouncing: 'subtle_elastic',
+    },
+  },
+  accent_layers: {
+    accent: {
+      accent_channel: 'chromatic_stitching',
+      complementary_channel: 'plasma_highlights',
+      effect_sync: 'hover_accent_layer',
+      intensity_curve: 'ease_out_quad',
+    },
+    complementary: {
+      accent_channel: 'anchoring_grid',
+      complementary_channel: 'mist_envelope',
+      effect_sync: 'hover_complementary_layer',
+      intensity_curve: 'ease_in_sine',
+    },
+  },
+};
+
+export const VIDEO_EXPANSION_CONFIG: VideoExpansionDefinition = {
+  expansion_states: {
+    thumbnail: {
+      size: '100%_of_card',
+      visualizer_role: 'background_ambient',
+      play_button_overlay: 'center_with_glow',
+      controls: 'overlay_button',
+    },
+    playing: {
+      size: '150%_of_original',
+      z_index: '1000',
+      background_blur: 'other_elements',
+      visualizer_role: 'audio_reactive',
+      controls: 'floating_transparent',
+    },
+    fullscreen: {
+      size: '100vw_100vh',
+      background: 'pure_black',
+      visualizer_role: 'immersive_audio_visual',
+      controls: 'minimal_overlay',
+    },
+  },
+  transitions: {
+    thumbnail_to_playing: {
+      duration: '500ms',
+      easing: 'ease_out_expo',
+      visualizer_morph: 'ambient_to_audio_reactive',
+    },
+    playing_to_fullscreen: {
+      duration: '300ms',
+      easing: 'ease_in_out',
+      visualizer_morph: 'audio_reactive_to_immersive',
+    },
+  },
+  accent_layers: {
+    accent: {
+      effect: 'video_accent_halo',
+      duration: '450ms',
+      overlay: 'perimeter_gradient',
+    },
+    complementary: {
+      effect: 'video_complementary_trace',
+      duration: '380ms',
+      overlay: 'background_mesh',
+    },
+  },
+};
+
+export const CONTENT_MANAGEMENT_CONFIG: ContentManagementDefinition = {
+  sections: [
+    {
+      id: 'section_type',
+      type: 'dropdown',
+      options: ['article_grid', 'video_gallery', 'audio_playlist', 'image_showcase', 'custom_layout'],
+    },
+    {
+      id: 'scrolling',
+      type: 'toggle',
+      options: ['enabled', 'disabled'],
+      subOptions: {
+        enabled: ['smooth', 'snap', 'infinite'],
+        scroll_direction: ['vertical', 'horizontal', 'both'],
+      },
+    },
+    {
+      id: 'expansion',
+      type: 'toggle',
+      options: ['enabled', 'disabled'],
+      subOptions: {
+        enabled: ['click', 'hover', 'auto'],
+        expansion_size: ['1.5x', '2x', 'fullscreen'],
+      },
+    },
+  ],
+  actions: [
+    {
+      id: 'add_content',
+      type: 'button',
+      label: 'Add Content Item',
+      actions: ['open_content_editor'],
+    },
+    {
+      id: 'content_list',
+      type: 'sortable_list',
+      label: 'Content Items',
+      actions: ['edit', 'delete', 'duplicate', 'reorder'],
+    },
+  ],
+  accentSettings: [
+    {
+      id: 'accent_overprint',
+      label: 'Accent Overprint',
+      description: 'Layer chromatic flares on hover-responsive cards.',
+      defaultState: 'enabled',
+    },
+    {
+      id: 'complimentary_ground',
+      label: 'Complementary Ground',
+      description: 'Stabilize layouts with counterbalancing depth fog.',
+      defaultState: 'enabled',
+    },
+  ],
+};
+

--- a/lib/design-system/editor-config.ts
+++ b/lib/design-system/editor-config.ts
@@ -1,0 +1,257 @@
+import { EditorControlDefinition, EditorPanelDefinition } from './types';
+
+const visualizerControls: EditorControlDefinition[] = [
+  {
+    id: 'visualizer_density',
+    type: 'dropdown',
+    label: 'Density',
+    options: [
+      { label: 'Minimal', value: 'minimal' },
+      { label: 'Standard', value: 'standard' },
+      { label: 'Dense', value: 'dense' },
+      { label: 'Maximum', value: 'maximum' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'visualizer_speed',
+    type: 'dropdown',
+    label: 'Speed',
+    options: [
+      { label: 'Static', value: 'static' },
+      { label: 'Calm', value: 'calm' },
+      { label: 'Flowing', value: 'flowing' },
+      { label: 'Energetic', value: 'energetic' },
+      { label: 'Frenetic', value: 'frenetic' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'visualizer_reactivity',
+    type: 'dropdown',
+    label: 'Reactivity',
+    options: [
+      { label: 'Passive', value: 'passive' },
+      { label: 'Responsive', value: 'responsive' },
+      { label: 'Highly Reactive', value: 'highly_reactive' },
+      { label: 'Hypersensitive', value: 'hypersensitive' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'visualizer_color',
+    type: 'dropdown',
+    label: 'Color Scheme',
+    options: [
+      { label: 'Monochrome', value: 'monochrome' },
+      { label: 'Complementary', value: 'complementary' },
+      { label: 'Triadic', value: 'triadic' },
+      { label: 'Analogous', value: 'analogous' },
+      { label: 'Rainbow', value: 'rainbow' },
+    ],
+    livePreview: true,
+  },
+];
+
+const interactionControls: EditorControlDefinition[] = [
+  {
+    id: 'hover_effect',
+    type: 'dropdown',
+    label: 'Hover Effect',
+    options: [
+      { label: 'Subtle Glow', value: 'subtle_glow' },
+      { label: 'Magnetic Attraction', value: 'magnetic_attraction' },
+      { label: 'Reality Distortion', value: 'reality_distortion' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'click_effect',
+    type: 'dropdown',
+    label: 'Click Effect',
+    options: [
+      { label: 'Color Inversion', value: 'color_inversion' },
+      { label: 'Reality Glitch', value: 'reality_glitch' },
+      { label: 'Quantum Collapse', value: 'quantum_collapse' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'scroll_effect',
+    type: 'dropdown',
+    label: 'Scroll Effect',
+    options: [
+      { label: 'Momentum Trails', value: 'momentum_trails' },
+      { label: 'Chaos Buildup', value: 'chaos_buildup' },
+      { label: 'Harmonic Resonance', value: 'harmonic_resonance' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'accent_overlay',
+    type: 'dropdown',
+    label: 'Accent Overlay',
+    options: [
+      { label: 'Chromatic Stitching', value: 'chromatic_stitching' },
+      { label: 'Plasma Highlights', value: 'plasma_highlights' },
+      { label: 'Halo Bloom', value: 'halo_bloom' },
+    ],
+    livePreview: true,
+  },
+  {
+    id: 'complementary_overlay',
+    type: 'dropdown',
+    label: 'Complementary Overlay',
+    options: [
+      { label: 'Anchoring Grid', value: 'anchoring_grid' },
+      { label: 'Mist Envelope', value: 'mist_envelope' },
+      { label: 'Ground Fog', value: 'ground_fog' },
+    ],
+    livePreview: true,
+  },
+];
+
+const transitionControls: EditorControlDefinition[] = [
+  {
+    id: 'page_transition',
+    type: 'dropdown',
+    label: 'Page Transition',
+    options: [
+      { label: 'Fade Cross', value: 'fade_cross' },
+      { label: 'Slide Portal', value: 'slide_portal' },
+      { label: 'Spiral Morph', value: 'spiral_morph' },
+      { label: 'Glitch Burst', value: 'glitch_burst' },
+    ],
+    previewActionId: 'test_transition',
+  },
+  {
+    id: 'card_transition',
+    type: 'dropdown',
+    label: 'Card Transition',
+    options: [
+      { label: 'Gentle Emerge', value: 'gentle_emerge' },
+      { label: 'Dramatic Burst', value: 'dramatic_burst' },
+      { label: 'Liquid Flow', value: 'liquid_flow' },
+    ],
+    previewActionId: 'test_card_animation',
+  },
+];
+
+const advancedControls: EditorControlDefinition[] = [
+  {
+    id: 'global_speed_multiplier',
+    type: 'slider',
+    label: 'Global Speed Multiplier',
+    range: [0.1, 3.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+  {
+    id: 'interaction_sensitivity',
+    type: 'slider',
+    label: 'Interaction Sensitivity',
+    range: [0.1, 2.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+  {
+    id: 'transition_duration_multiplier',
+    type: 'slider',
+    label: 'Transition Duration Multiplier',
+    range: [0.5, 2.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+  {
+    id: 'accent_layer_intensity',
+    type: 'slider',
+    label: 'Accent Layer Intensity',
+    range: [0.0, 2.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+  {
+    id: 'complementary_layer_intensity',
+    type: 'slider',
+    label: 'Complementary Layer Intensity',
+    range: [0.0, 2.0],
+    step: 0.1,
+    defaultValue: 1.0,
+    livePreview: true,
+  },
+];
+
+export const STYLE_SETTINGS_PANEL: EditorPanelDefinition = {
+  id: 'style_settings',
+  sections: [
+    { id: 'visualizer_configuration', title: 'Visualizer Configuration', controls: visualizerControls },
+    { id: 'interaction_behavior', title: 'Interaction Behavior', controls: interactionControls },
+    { id: 'transition_style', title: 'Transition Style', controls: transitionControls },
+    { id: 'advanced_tuning', title: 'Advanced Tuning', controls: advancedControls },
+  ],
+};
+
+export const CONTENT_MANAGEMENT_PANEL: EditorPanelDefinition = {
+  id: 'content_management',
+  sections: [
+    {
+      id: 'section_configuration',
+      title: 'Section Configuration',
+      controls: [
+        {
+          id: 'section_type',
+          type: 'dropdown',
+          label: 'Section Type',
+          options: [
+            { label: 'Article Grid', value: 'article_grid' },
+            { label: 'Video Gallery', value: 'video_gallery' },
+            { label: 'Audio Playlist', value: 'audio_playlist' },
+            { label: 'Image Showcase', value: 'image_showcase' },
+            { label: 'Custom Layout', value: 'custom_layout' },
+          ],
+        },
+        {
+          id: 'scrolling_toggle',
+          type: 'toggle',
+          label: 'Scrolling',
+          options: [
+            { label: 'Enabled', value: 'enabled' },
+            { label: 'Disabled', value: 'disabled' },
+          ],
+        },
+        {
+          id: 'expansion_toggle',
+          type: 'toggle',
+          label: 'Expansion',
+          options: [
+            { label: 'Enabled', value: 'enabled' },
+            { label: 'Disabled', value: 'disabled' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'content_items',
+      title: 'Content Items',
+      controls: [
+        {
+          id: 'add_content',
+          type: 'button',
+          label: 'Add Content',
+          actions: ['open_content_editor'],
+        },
+        {
+          id: 'content_list',
+          type: 'sortable_list',
+          label: 'Content List',
+          actions: ['edit', 'delete', 'duplicate', 'reorder'],
+        },
+      ],
+    },
+  ],
+};
+

--- a/lib/design-system/index.ts
+++ b/lib/design-system/index.ts
@@ -1,0 +1,9 @@
+export * from './constants';
+export * from './content-integration';
+export * from './editor-config';
+export * from './interaction-coordinator';
+export * from './preset-manager';
+export * from './presets';
+export * from './transition-coordinator';
+export * from './types';
+

--- a/lib/design-system/interaction-coordinator.ts
+++ b/lib/design-system/interaction-coordinator.ts
@@ -1,0 +1,605 @@
+import {
+  ClickEffectPreset,
+  ClickInteractionResult,
+  ClickResponseDefinition,
+  DesignSystemAdvancedTuning,
+  HoverEffectPreset,
+  HoverInteractionResult,
+  HoverResponseDefinition,
+  ParameterPatch,
+  ScrollEffectPreset,
+  ScrollInteractionResult,
+  SectionParameterSnapshot,
+  SectionVisualState,
+  LayerVisualState,
+  VisualStateMultipliers,
+} from './types';
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+const parseScalarOperation = (operation: string): number => {
+  if (operation.startsWith('increase_')) {
+    const value = operation.replace('increase_', '').replace('x', '');
+    return parseFloat(value);
+  }
+  if (operation.startsWith('decrease_')) {
+    const value = operation.replace('decrease_', '').replace('x', '');
+    return parseFloat(value);
+  }
+  return 1;
+};
+
+const parseDepthOperation = (operation: string): number => {
+  if (operation.startsWith('lift_forward_')) {
+    const value = operation.replace('lift_forward_', '').replace('px', '');
+    return parseFloat(value);
+  }
+  if (operation.startsWith('push_back_')) {
+    const value = operation.replace('push_back_', '').replace('px', '');
+    return -parseFloat(value);
+  }
+  return 0;
+};
+
+const parseDurationMs = (value: string): number => {
+  const match = value.match(/([0-9.]+)ms/);
+  return match ? parseFloat(match[1]) : 0;
+};
+
+const applyLayerOperations = (
+  base: LayerVisualState,
+  scalarOps: { gridDensity: string; colorIntensity: string; reactivity: string; depth: string },
+  effect: Partial<VisualStateMultipliers> | undefined,
+  timestamp: number
+): LayerVisualState => {
+  const gridMultiplier = parseScalarOperation(scalarOps.gridDensity) * (effect?.gridDensity ?? 1);
+  const colorMultiplier = parseScalarOperation(scalarOps.colorIntensity) * (effect?.colorIntensity ?? 1);
+  const reactivityMultiplier = parseScalarOperation(scalarOps.reactivity) * (effect?.reactivity ?? 1);
+  const depthDelta = parseDepthOperation(scalarOps.depth) + (effect?.depth ?? 0);
+
+  return {
+    gridDensity: clamp(base.gridDensity * gridMultiplier, 0.1, 4),
+    colorIntensity: clamp(base.colorIntensity * colorMultiplier, 0.2, 4),
+    reactivity: clamp(base.reactivity * reactivityMultiplier, 0.2, 5),
+    depth: clamp(base.depth + depthDelta, -60, 60),
+    lastUpdated: timestamp,
+  };
+};
+
+const applyModifierLayer = (
+  base: LayerVisualState,
+  modifiers: Partial<VisualStateMultipliers> | undefined,
+  intensity: number,
+  timestamp: number
+): LayerVisualState | undefined => {
+  if (!modifiers) {
+    return undefined;
+  }
+
+  return {
+    gridDensity: clamp(base.gridDensity * ((modifiers.gridDensity ?? 1) + intensity * 0.02), 0.1, 4),
+    colorIntensity: clamp(base.colorIntensity * ((modifiers.colorIntensity ?? 1) + intensity * 0.02), 0.2, 4.5),
+    reactivity: clamp(base.reactivity * ((modifiers.reactivity ?? 1) + intensity * 0.03), 0.2, 5.5),
+    depth: clamp(base.depth + (modifiers.depth ?? 0) * intensity * 0.4, -60, 60),
+    lastUpdated: timestamp,
+  };
+};
+
+const combineLayerStates = (
+  primary: LayerVisualState,
+  accent?: LayerVisualState,
+  complementary?: LayerVisualState
+): LayerVisualState => {
+  const gridDensity = clamp(
+    primary.gridDensity + (accent ? accent.gridDensity - 1 : 0) + (complementary ? complementary.gridDensity - 1 : 0),
+    0.1,
+    4.5
+  );
+  const colorIntensity = clamp(
+    primary.colorIntensity + (accent ? accent.colorIntensity - 1 : 0) + (complementary ? complementary.colorIntensity - 1 : 0),
+    0.2,
+    5
+  );
+  const reactivity = clamp(
+    primary.reactivity + (accent ? accent.reactivity - 1 : 0) + (complementary ? complementary.reactivity - 1 : 0),
+    0.2,
+    6
+  );
+  const depth = clamp(
+    primary.depth + (accent?.depth ?? 0) + (complementary?.depth ?? 0),
+    -70,
+    70
+  );
+
+  return {
+    gridDensity,
+    colorIntensity,
+    reactivity,
+    depth,
+    lastUpdated: primary.lastUpdated,
+  };
+};
+
+const mapVisualStateToParams = (
+  visualState: SectionVisualState,
+  baseParams: SectionParameterSnapshot[string],
+  advanced: DesignSystemAdvancedTuning
+): ParameterPatch => {
+  const accentGridDelta = visualState.accentLayer ? visualState.accentLayer.gridDensity - 1 : 0;
+  const complementaryGridDelta = visualState.complementaryLayer ? visualState.complementaryLayer.gridDensity - 1 : 0;
+  const accentColorDelta = visualState.accentLayer ? visualState.accentLayer.colorIntensity - 1 : 0;
+  const complementaryColorDelta = visualState.complementaryLayer ? visualState.complementaryLayer.colorIntensity - 1 : 0;
+  const accentReactivityDelta = visualState.accentLayer ? visualState.accentLayer.reactivity - 1 : 0;
+  const complementaryReactivityDelta = visualState.complementaryLayer ? visualState.complementaryLayer.reactivity - 1 : 0;
+  const layeredDepth = visualState.depth + (visualState.accentLayer?.depth ?? 0) + (visualState.complementaryLayer?.depth ?? 0);
+
+  const paramPatch: ParameterPatch = {};
+  const densityMultiplier = clamp(
+    visualState.gridDensity + accentGridDelta * 0.8 + complementaryGridDelta * 0.6,
+    0.1,
+    2.5
+  );
+  paramPatch.density = clamp(baseParams.density * densityMultiplier, 0, 1.6);
+
+  const chromaMultiplier = clamp(
+    visualState.colorIntensity + accentColorDelta * 0.9 + complementaryColorDelta * 0.7,
+    0.1,
+    3
+  );
+  paramPatch.chromaShift = clamp(baseParams.chromaShift * chromaMultiplier, -1.5, 1.5);
+
+  const reactivityMultiplier = clamp(
+    visualState.reactivity + accentReactivityDelta * 1.1 + complementaryReactivityDelta * 0.85,
+    0.1,
+    6.5
+  );
+  const reactivityBoost = reactivityMultiplier * advanced.speedMultiplier * advanced.interactionSensitivity;
+  paramPatch.timeScale = clamp(baseParams.timeScale * reactivityBoost, -6, 6);
+
+  paramPatch.dispAmp = clamp(baseParams.dispAmp + layeredDepth * 0.0012, 0, 1.6);
+  paramPatch.glitch = clamp(baseParams.glitch + Math.max(0, accentGridDelta * 0.05) + Math.max(0, complementaryColorDelta * 0.04), 0, 1);
+  return paramPatch;
+};
+
+export const createDefaultSectionVisualState = (): SectionVisualState => ({
+  gridDensity: 1,
+  colorIntensity: 1,
+  reactivity: 1,
+  depth: 0,
+  lastUpdated: Date.now(),
+  accentLayer: undefined,
+  complementaryLayer: undefined,
+  accentEffect: undefined,
+  complementaryEffect: undefined,
+});
+
+interface HoverInteractionContext {
+  targetId: string;
+  sectionStates: Record<string, SectionVisualState>;
+  params: SectionParameterSnapshot;
+  hoverResponse: HoverResponseDefinition;
+  effect: HoverEffectPreset;
+  advanced: DesignSystemAdvancedTuning;
+  timestamp: number;
+}
+
+export const applyHoverInteraction = ({
+  targetId,
+  sectionStates,
+  params,
+  hoverResponse,
+  effect,
+  advanced,
+  timestamp,
+}: HoverInteractionContext): HoverInteractionResult => {
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  const paramPatches: Record<string, ParameterPatch> = {};
+  const sectionIds = Object.keys(params);
+
+  sectionIds.forEach((sectionId) => {
+    const baseParams = params[sectionId];
+    if (!baseParams) {
+      return;
+    }
+    const baseState = nextStates[sectionId] ?? createDefaultSectionVisualState();
+    const isTarget = sectionId === targetId;
+    const scalarOps = isTarget ? hoverResponse.target : hoverResponse.others;
+    const modifiers = isTarget ? effect.targetModifiers : effect.othersModifiers;
+    const primaryLayer = applyLayerOperations(baseState, scalarOps, modifiers ?? {}, timestamp);
+
+    const accentOps = hoverResponse.accent
+      ? (isTarget ? hoverResponse.accent.target : hoverResponse.accent.others)
+      : undefined;
+    const accentModifiers = isTarget ? effect.accentTargetModifiers : effect.accentOthersModifiers;
+    const accentLayer = accentOps
+      ? applyLayerOperations(primaryLayer, accentOps, accentModifiers ?? {}, timestamp)
+      : undefined;
+
+    const complementOps = hoverResponse.complementary
+      ? (isTarget ? hoverResponse.complementary.target : hoverResponse.complementary.others)
+      : undefined;
+    const complementModifiers = isTarget ? effect.complementTargetModifiers : effect.complementOthersModifiers;
+    const complementaryLayer = complementOps
+      ? applyLayerOperations(primaryLayer, complementOps, complementModifiers ?? {}, timestamp)
+      : undefined;
+
+    const composite = combineLayerStates(primaryLayer, accentLayer, complementaryLayer);
+
+    const accentEffect = accentLayer
+      ? effect.accentEffect
+        ? { type: effect.accentEffect.type, startedAt: timestamp, duration: effect.accentEffect.duration }
+        : {
+            type: 'hover_accent_layer',
+            startedAt: timestamp,
+            duration: parseDurationMs(hoverResponse.transition.duration),
+          }
+      : baseState.accentEffect;
+
+    const complementaryEffect = complementaryLayer
+      ? effect.complementEffect
+        ? { type: effect.complementEffect.type, startedAt: timestamp, duration: effect.complementEffect.duration }
+        : {
+            type: 'hover_complementary_layer',
+            startedAt: timestamp,
+            duration: parseDurationMs(hoverResponse.transition.duration),
+          }
+      : baseState.complementaryEffect;
+
+    const updatedState: SectionVisualState = {
+      ...baseState,
+      ...composite,
+      accentLayer,
+      complementaryLayer,
+      accentEffect,
+      complementaryEffect,
+      lastUpdated: timestamp,
+    };
+
+    nextStates[sectionId] = updatedState;
+    paramPatches[sectionId] = mapVisualStateToParams(updatedState, baseParams, advanced);
+  });
+
+  const baseDuration = parseDurationMs(hoverResponse.transition.duration);
+  const layerCount = 1 + (hoverResponse.accent ? 1 : 0) + (hoverResponse.complementary ? 1 : 0);
+  const averageMultiplier =
+    (effect.transitionSpeedMultiplier +
+      (hoverResponse.accent ? effect.accentTransitionSpeedMultiplier ?? effect.transitionSpeedMultiplier : 0) +
+      (hoverResponse.complementary
+        ? effect.complementTransitionSpeedMultiplier ?? effect.transitionSpeedMultiplier
+        : 0)) /
+    Math.max(1, layerCount);
+  const duration = baseDuration * averageMultiplier * advanced.transitionDurationMultiplier;
+  const stagger =
+    parseDurationMs(hoverResponse.transition.stagger) +
+    (hoverResponse.accent ? 20 : 0) +
+    (hoverResponse.complementary ? 15 : 0);
+
+  return {
+    sectionStates: nextStates,
+    paramPatches,
+    transitionDuration: duration,
+    transitionEasing: hoverResponse.transition.easing,
+    stagger,
+  };
+};
+
+interface ClickInteractionContext {
+  targetId: string;
+  sectionStates: Record<string, SectionVisualState>;
+  params: SectionParameterSnapshot;
+  clickResponse: ClickResponseDefinition;
+  effect: ClickEffectPreset;
+  advanced: DesignSystemAdvancedTuning;
+  timestamp: number;
+}
+
+const invertValue = (value: number, min = 0, max = 1): number => clamp(max - (value - min), min, max);
+
+export const applyClickInteraction = ({
+  targetId,
+  sectionStates,
+  params,
+  clickResponse,
+  effect,
+  advanced,
+  timestamp,
+}: ClickInteractionContext): ClickInteractionResult => {
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  const paramPatches: Record<string, ParameterPatch> = {};
+
+  Object.keys(params).forEach((sectionId) => {
+    const baseParams = params[sectionId];
+    if (!baseParams) {
+      return;
+    }
+
+    const baseState = nextStates[sectionId] ?? createDefaultSectionVisualState();
+    const isTarget = sectionId === targetId;
+
+    const primaryOps = isTarget ? clickResponse.primary.target : clickResponse.primary.others;
+    const primaryModifiers = isTarget ? effect.targetModifiers : effect.othersModifiers;
+    const primaryLayer = applyLayerOperations(baseState, primaryOps, primaryModifiers ?? {}, timestamp);
+
+    const accentOps = clickResponse.accent
+      ? (isTarget ? clickResponse.accent.target : clickResponse.accent.others)
+      : undefined;
+    const accentModifiers = isTarget ? effect.accentTargetModifiers : effect.accentOthersModifiers;
+    const accentLayer = accentOps
+      ? applyLayerOperations(primaryLayer, accentOps, accentModifiers ?? {}, timestamp)
+      : undefined;
+
+    const complementaryOps = clickResponse.complementary
+      ? (isTarget ? clickResponse.complementary.target : clickResponse.complementary.others)
+      : undefined;
+    const complementaryModifiers = isTarget ? effect.complementTargetModifiers : effect.complementOthersModifiers;
+    const complementaryLayer = complementaryOps
+      ? applyLayerOperations(primaryLayer, complementaryOps, complementaryModifiers ?? {}, timestamp)
+      : undefined;
+
+    const composite = combineLayerStates(primaryLayer, accentLayer, complementaryLayer);
+
+    let rippleEffect = baseState.rippleEffect;
+    let sparkleEffect = baseState.sparkleEffect;
+    let accentEffect = baseState.accentEffect;
+    let complementaryEffect = baseState.complementaryEffect;
+    let inversionActiveUntil = baseState.inversionActiveUntil;
+
+    if (isTarget) {
+      rippleEffect = {
+        type: clickResponse.immediate.rippleEffect,
+        startedAt: timestamp,
+        duration: parseDurationMs(clickResponse.duration.decay),
+      };
+      sparkleEffect = {
+        type: clickResponse.immediate.sparkleGeneration,
+        startedAt: timestamp,
+        duration: effect.sparkleDuration,
+        count: effect.sparkleCount,
+      };
+      inversionActiveUntil = timestamp + effect.inversionDuration;
+
+      if (clickResponse.accent) {
+        accentEffect = {
+          type: clickResponse.accent.rippleEffect,
+          startedAt: timestamp,
+          duration: effect.accentRippleDuration ?? parseDurationMs(clickResponse.accent.duration),
+          data: { sparkle: effect.accentSparkleCount ?? effect.sparkleCount },
+        };
+      } else if (accentLayer) {
+        accentEffect = {
+          type: 'click_accent_field',
+          startedAt: timestamp,
+          duration: effect.accentRippleDuration ?? 800,
+        };
+      }
+
+      if (clickResponse.complementary) {
+        complementaryEffect = {
+          type: clickResponse.complementary.rippleEffect,
+          startedAt: timestamp,
+          duration: effect.complementaryRippleDuration ?? parseDurationMs(clickResponse.complementary.duration),
+          data: {
+            sparkle: effect.complementarySparkleCount ?? Math.max(4, Math.floor(effect.sparkleCount * 0.75)),
+          },
+        };
+      } else if (complementaryLayer) {
+        complementaryEffect = {
+          type: 'click_complementary_field',
+          startedAt: timestamp,
+          duration: effect.complementaryRippleDuration ?? 650,
+        };
+      }
+    } else {
+      if (accentLayer && clickResponse.accent) {
+        accentEffect = {
+          type: clickResponse.accent.rippleEffect,
+          startedAt: timestamp,
+          duration: effect.accentRippleDuration ?? parseDurationMs(clickResponse.accent.duration),
+        };
+      }
+      if (complementaryLayer && clickResponse.complementary) {
+        complementaryEffect = {
+          type: clickResponse.complementary.rippleEffect,
+          startedAt: timestamp,
+          duration: effect.complementaryRippleDuration ?? parseDurationMs(clickResponse.complementary.duration),
+        };
+      }
+    }
+
+    const updatedState: SectionVisualState = {
+      ...baseState,
+      ...composite,
+      accentLayer,
+      complementaryLayer,
+      rippleEffect,
+      sparkleEffect,
+      accentEffect,
+      complementaryEffect,
+      inversionActiveUntil,
+      lastUpdated: timestamp,
+    };
+
+    nextStates[sectionId] = updatedState;
+
+    const patch = mapVisualStateToParams(updatedState, baseParams, advanced);
+
+    if (isTarget) {
+      if (clickResponse.immediate.variableInversion.density === 'inverse_value') {
+        patch.density = invertValue(baseParams.density, 0, 1);
+      }
+      if (clickResponse.immediate.variableInversion.intensity === 'flip_polarity') {
+        patch.chromaShift = invertValue(baseParams.chromaShift, -1.5, 1.5);
+      }
+      if (clickResponse.immediate.variableInversion.speed === 'reverse_direction') {
+        const reversed = -Math.abs(baseParams.timeScale);
+        patch.timeScale = clamp(reversed, -6, 6) * advanced.speedMultiplier;
+      }
+      patch.glitch = clamp((patch.glitch ?? baseParams.glitch) + 0.25, 0, 1);
+      if (effect.accentSparkleDuration && clickResponse.accent) {
+        patch.morph = clamp((baseParams.morph ?? 1) * 1.1, 0, 2);
+      }
+    } else {
+      patch.glitch = clamp((patch.glitch ?? baseParams.glitch) + 0.08, 0, 1);
+    }
+
+    paramPatches[sectionId] = patch;
+  });
+
+  return {
+    sectionStates: nextStates,
+    paramPatches,
+  };
+};
+
+interface ScrollInteractionContext {
+  direction: 'up' | 'down';
+  velocity: number;
+  sectionStates: Record<string, SectionVisualState>;
+  params: SectionParameterSnapshot;
+  effect: ScrollEffectPreset;
+  advanced: DesignSystemAdvancedTuning;
+  timestamp: number;
+}
+
+const computeScrollIntensity = (velocity: number, effect: ScrollEffectPreset, timestamp: number): number => {
+  const magnitude = Math.abs(velocity);
+  switch (effect.intensityModel) {
+    case 'velocity':
+      return clamp(magnitude, 0, 4);
+    case 'threshold':
+      return magnitude > (effect.threshold ?? 5) ? clamp(magnitude * 0.5, 0, 4) : 0.2;
+    case 'harmonic':
+      return clamp(2 + Math.sin(timestamp / 300), 0, 4);
+    default:
+      return clamp(magnitude, 0, 4);
+  }
+};
+
+export const applyScrollInteraction = ({
+  direction,
+  velocity,
+  sectionStates,
+  params,
+  effect,
+  advanced,
+  timestamp,
+}: ScrollInteractionContext): ScrollInteractionResult => {
+  const intensity = computeScrollIntensity(velocity, effect, timestamp) * advanced.interactionSensitivity;
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  const paramPatches: Record<string, ParameterPatch> = {};
+
+  Object.keys(params).forEach((sectionId) => {
+    const baseParams = params[sectionId];
+    if (!baseParams) {
+      return;
+    }
+    const baseState = nextStates[sectionId] ?? createDefaultSectionVisualState();
+    const delta = direction === 'up' ? intensity * 0.1 : -intensity * 0.1;
+    const primaryLayer: LayerVisualState = {
+      gridDensity: clamp(baseState.gridDensity + delta, 0.2, 4.2),
+      reactivity: clamp(baseState.reactivity + intensity * 0.05, 0.2, 5.5),
+      colorIntensity: clamp(baseState.colorIntensity + intensity * 0.03, 0.2, 5.2),
+      depth: clamp(baseState.depth + (direction === 'up' ? 1 : -1) * intensity * 0.5, -55, 55),
+      lastUpdated: timestamp,
+    };
+
+    const accentLayer = applyModifierLayer(primaryLayer, effect.accentModifiers, intensity, timestamp);
+    const complementaryLayer = applyModifierLayer(primaryLayer, effect.complementaryModifiers, intensity, timestamp);
+    const composite = combineLayerStates(primaryLayer, accentLayer, complementaryLayer);
+
+    const rippleEffect = effect.decayModel === 'wave'
+      ? { type: 'scroll_wave', startedAt: timestamp, duration: 600 }
+      : baseState.rippleEffect;
+
+    const accentEffect = accentLayer
+      ? effect.accentEffect
+        ? { type: effect.accentEffect.type, startedAt: timestamp, duration: effect.accentEffect.duration }
+        : { type: 'scroll_accent_trail', startedAt: timestamp, duration: 520 }
+      : baseState.accentEffect;
+
+    const complementaryEffect = complementaryLayer
+      ? effect.complementaryEffect
+        ? { type: effect.complementaryEffect.type, startedAt: timestamp, duration: effect.complementaryEffect.duration }
+        : { type: 'scroll_complement_trail', startedAt: timestamp, duration: 460 }
+      : baseState.complementaryEffect;
+
+    const updatedState: SectionVisualState = {
+      ...baseState,
+      ...composite,
+      accentLayer,
+      complementaryLayer,
+      rippleEffect,
+      accentEffect,
+      complementaryEffect,
+      lastUpdated: timestamp,
+    };
+
+    nextStates[sectionId] = updatedState;
+    paramPatches[sectionId] = mapVisualStateToParams(updatedState, baseParams, advanced);
+  });
+
+  return { sectionStates: nextStates, paramPatches };
+};
+
+export const resetSectionVisualStates = (
+  sectionStates: Record<string, SectionVisualState>,
+  sectionIds?: string[]
+): Record<string, SectionVisualState> => {
+  if (!sectionIds || sectionIds.length === 0) {
+    return {};
+  }
+
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  sectionIds.forEach((id) => {
+    nextStates[id] = createDefaultSectionVisualState();
+  });
+  return nextStates;
+};
+
+export const pruneExpiredEffects = (
+  sectionStates: Record<string, SectionVisualState>,
+  timestamp: number
+): Record<string, SectionVisualState> => {
+  const nextStates: Record<string, SectionVisualState> = { ...sectionStates };
+  Object.entries(nextStates).forEach(([id, state]) => {
+    if (!state) return;
+    let rippleEffect = state.rippleEffect;
+    if (rippleEffect && timestamp - rippleEffect.startedAt > rippleEffect.duration) {
+      rippleEffect = undefined;
+    }
+    let sparkleEffect = state.sparkleEffect;
+    if (sparkleEffect && timestamp - sparkleEffect.startedAt > sparkleEffect.duration) {
+      sparkleEffect = undefined;
+    }
+    let accentEffect = state.accentEffect;
+    if (accentEffect && timestamp - accentEffect.startedAt > accentEffect.duration) {
+      accentEffect = undefined;
+    }
+    let complementaryEffect = state.complementaryEffect;
+    if (complementaryEffect && timestamp - complementaryEffect.startedAt > complementaryEffect.duration) {
+      complementaryEffect = undefined;
+    }
+    let accentLayer = state.accentLayer;
+    if (accentLayer && timestamp - accentLayer.lastUpdated > 1200) {
+      accentLayer = undefined;
+    }
+    let complementaryLayer = state.complementaryLayer;
+    if (complementaryLayer && timestamp - complementaryLayer.lastUpdated > 1200) {
+      complementaryLayer = undefined;
+    }
+    const inversionActive = state.inversionActiveUntil && timestamp > state.inversionActiveUntil;
+
+    nextStates[id] = {
+      ...state,
+      rippleEffect,
+      sparkleEffect,
+      accentEffect,
+      complementaryEffect,
+      accentLayer,
+      complementaryLayer,
+      inversionActiveUntil: inversionActive ? undefined : state.inversionActiveUntil,
+    };
+  });
+  return nextStates;
+};
+

--- a/lib/design-system/preset-manager.ts
+++ b/lib/design-system/preset-manager.ts
@@ -1,0 +1,190 @@
+import {
+  cardTransitionPresets,
+  clickEffectPresets,
+  hoverEffectPresets,
+  pageTransitionPresets,
+  scrollEffectPresets,
+  visualizerColorPresets,
+  visualizerDensityPresets,
+  visualizerReactivityPresets,
+  visualizerSpeedPresets,
+  accentOverlayPresets,
+  complementaryOverlayPresets,
+} from './presets';
+import {
+  CardTransitionPreset,
+  ClickEffectPreset,
+  DesignSystemAdvancedTuning,
+  HoverEffectPreset,
+  MinimalParamsSnapshot,
+  PageTransitionPreset,
+  ParameterPatch,
+  ScrollEffectPreset,
+  VisualizerColorPreset,
+  VisualizerDensityPreset,
+  VisualizerReactivityPreset,
+  VisualizerSpeedPreset,
+} from './types';
+
+export type PresetCategory =
+  | 'visualizer'
+  | 'speed'
+  | 'reactivity'
+  | 'color'
+  | 'hoverEffect'
+  | 'clickEffect'
+  | 'scrollEffect'
+  | 'pageTransition'
+  | 'cardTransition'
+  | 'accentOverlay'
+  | 'complementaryOverlay';
+
+export class PresetManager {
+  private customPresets: Record<string, ParameterPatch> = {};
+
+  list(category: PresetCategory): string[] {
+    switch (category) {
+      case 'visualizer':
+        return Object.keys(visualizerDensityPresets);
+      case 'speed':
+        return Object.keys(visualizerSpeedPresets);
+      case 'reactivity':
+        return Object.keys(visualizerReactivityPresets);
+      case 'color':
+        return Object.keys(visualizerColorPresets);
+      case 'hoverEffect':
+        return Object.keys(hoverEffectPresets);
+      case 'clickEffect':
+        return Object.keys(clickEffectPresets);
+      case 'scrollEffect':
+        return Object.keys(scrollEffectPresets);
+      case 'pageTransition':
+        return Object.keys(pageTransitionPresets);
+      case 'cardTransition':
+        return Object.keys(cardTransitionPresets);
+      case 'accentOverlay':
+        return Object.keys(accentOverlayPresets);
+      case 'complementaryOverlay':
+        return Object.keys(complementaryOverlayPresets);
+      default:
+        return [];
+    }
+  }
+
+  get(category: 'visualizer', name: string): VisualizerDensityPreset | undefined;
+  get(category: 'speed', name: string): VisualizerSpeedPreset | undefined;
+  get(category: 'reactivity', name: string): VisualizerReactivityPreset | undefined;
+  get(category: 'color', name: string): VisualizerColorPreset | undefined;
+  get(category: 'hoverEffect', name: string): HoverEffectPreset | undefined;
+  get(category: 'clickEffect', name: string): ClickEffectPreset | undefined;
+  get(category: 'scrollEffect', name: string): ScrollEffectPreset | undefined;
+  get(category: 'pageTransition', name: string): PageTransitionPreset | undefined;
+  get(category: 'cardTransition', name: string): CardTransitionPreset | undefined;
+  get(category: 'accentOverlay', name: string): ParameterPatch | undefined;
+  get(category: 'complementaryOverlay', name: string): ParameterPatch | undefined;
+  get(category: PresetCategory, name: string): unknown {
+    switch (category) {
+      case 'visualizer':
+        return visualizerDensityPresets[name];
+      case 'speed':
+        return visualizerSpeedPresets[name];
+      case 'reactivity':
+        return visualizerReactivityPresets[name];
+      case 'color':
+        return visualizerColorPresets[name];
+      case 'hoverEffect':
+        return hoverEffectPresets[name];
+      case 'clickEffect':
+        return clickEffectPresets[name];
+      case 'scrollEffect':
+        return scrollEffectPresets[name];
+      case 'pageTransition':
+        return pageTransitionPresets[name];
+      case 'cardTransition':
+        return cardTransitionPresets[name];
+      case 'accentOverlay':
+        return accentOverlayPresets[name];
+      case 'complementaryOverlay':
+        return complementaryOverlayPresets[name];
+      default:
+        return undefined;
+    }
+  }
+
+  computeHomePatch(
+    category: PresetCategory,
+    name: string,
+    base: MinimalParamsSnapshot,
+    advanced: DesignSystemAdvancedTuning
+  ): ParameterPatch | undefined {
+    switch (category) {
+      case 'visualizer':
+        return this.computeVisualizerPatch(name, base);
+      case 'speed':
+        return this.computeSpeedPatch(name, base, advanced);
+      case 'color':
+        return this.computeColorPatch(name);
+      case 'accentOverlay':
+        return accentOverlayPresets[name];
+      case 'complementaryOverlay':
+        return complementaryOverlayPresets[name];
+      default:
+        return undefined;
+    }
+  }
+
+  registerCustomPreset(name: string, patch: ParameterPatch): void {
+    this.customPresets[name] = patch;
+  }
+
+  getCustomPreset(name: string): ParameterPatch | undefined {
+    return this.customPresets[name];
+  }
+
+  listCustomPresets(): string[] {
+    return Object.keys(this.customPresets);
+  }
+
+  private computeVisualizerPatch(name: string, base: MinimalParamsSnapshot): ParameterPatch | undefined {
+    const preset = visualizerDensityPresets[name];
+    if (!preset) return undefined;
+    const normalized = Math.min(1, Math.max(0.125, preset.base / 32));
+    const variationNormalized = Math.min(1, Math.max(0, preset.variation / 8));
+    const density = Math.min(1.5, 0.2 + normalized * 0.8);
+    const dispAmp = Math.min(1.5, base.dispAmp + variationNormalized * 0.3);
+    return {
+      density,
+      dispAmp,
+    };
+  }
+
+  private computeSpeedPatch(
+    name: string,
+    base: MinimalParamsSnapshot,
+    advanced: DesignSystemAdvancedTuning
+  ): ParameterPatch | undefined {
+    const preset = visualizerSpeedPresets[name];
+    if (!preset) return undefined;
+    const multiplier = 1 + preset.base * 0.5;
+    const timeScale = Math.min(5, Math.max(0.1, base.timeScale * multiplier * advanced.speedMultiplier));
+    const morph = Math.min(2, Math.max(0, base.morph + preset.variation * 0.25));
+    return { timeScale, morph };
+  }
+
+  private computeColorPatch(name: string): ParameterPatch | undefined {
+    const palette = visualizerColorPresets[name];
+    if (!palette) return undefined;
+    const chromaMap: Record<string, number> = {
+      monochrome: 0.02,
+      complementary: 0.06,
+      triadic: 0.08,
+      analogous: 0.05,
+      rainbow: 0.12,
+    };
+    const chromaShift = chromaMap[name] ?? 0.06;
+    return { chromaShift };
+  }
+}
+
+export const createPresetManager = () => new PresetManager();
+

--- a/lib/design-system/presets.ts
+++ b/lib/design-system/presets.ts
@@ -1,0 +1,476 @@
+import {
+  CardTransitionPreset,
+  DesignSystemAdvancedTuning,
+  DesignSystemSelections,
+  HoverEffectPreset,
+  PageTransitionPreset,
+  ScrollEffectPreset,
+  VisualizerColorPreset,
+  VisualizerDensityPreset,
+  VisualizerReactivityPreset,
+  VisualizerSpeedPreset,
+  ClickEffectPreset,
+  ParameterPatch,
+} from './types';
+
+export const visualizerDensityPresets: Record<string, VisualizerDensityPreset> = {
+  minimal: { base: 4.0, variation: 1.0 },
+  standard: { base: 8.0, variation: 2.0 },
+  dense: { base: 16.0, variation: 4.0 },
+  maximum: { base: 32.0, variation: 8.0 },
+};
+
+export const visualizerSpeedPresets: Record<string, VisualizerSpeedPreset> = {
+  static: { base: 0.0, variation: 0.0 },
+  calm: { base: 0.3, variation: 0.1 },
+  flowing: { base: 0.6, variation: 0.2 },
+  energetic: { base: 1.2, variation: 0.4 },
+  frenetic: { base: 2.0, variation: 0.8 },
+};
+
+export const visualizerReactivityPresets: Record<string, VisualizerReactivityPreset> = {
+  passive: { mouse: 0.2, click: 0.1, scroll: 0.1 },
+  responsive: { mouse: 0.6, click: 0.4, scroll: 0.3 },
+  highly_reactive: { mouse: 1.0, click: 0.8, scroll: 0.6 },
+  hypersensitive: { mouse: 1.5, click: 1.2, scroll: 1.0 },
+};
+
+export const visualizerColorPresets: Record<string, VisualizerColorPreset> = {
+  monochrome: { palette: 'single_hue_variations' },
+  complementary: { palette: 'opposite_color_wheel' },
+  triadic: { palette: 'three_equidistant_hues' },
+  analogous: { palette: 'adjacent_color_wheel' },
+  rainbow: { palette: 'full_spectrum_cycle' },
+};
+
+export const pageTransitionPresets: Record<string, PageTransitionPreset> = {
+  fade_cross: {
+    outgoing: 'fade_to_black',
+    incoming: 'fade_from_black',
+    overlap: '200ms',
+    easing: 'ease_in_out',
+  },
+  slide_portal: {
+    outgoing: 'slide_to_edge_dissolve',
+    incoming: 'slide_from_opposite_edge',
+    overlap: '300ms',
+    easing: 'cubic_bezier_custom',
+  },
+  spiral_morph: {
+    outgoing: 'spiral_collapse_to_center',
+    incoming: 'spiral_emerge_from_center',
+    overlap: '400ms',
+    easing: 'ease_out_expo',
+  },
+  glitch_burst: {
+    outgoing: 'vhs_glitch_dissolve',
+    incoming: 'chromatic_aberration_emerge',
+    overlap: '150ms',
+    easing: 'ease_in_bounce',
+  },
+};
+
+export const cardTransitionPresets: Record<string, CardTransitionPreset> = {
+  gentle_emerge: {
+    from: 'background_layer',
+    animation: 'translucency_and_scale',
+    duration: '800ms',
+    easing: 'ease_out_quart',
+  },
+  dramatic_burst: {
+    from: 'screen_center',
+    animation: 'explosive_scale_and_spin',
+    duration: '1200ms',
+    easing: 'ease_out_back',
+  },
+  liquid_flow: {
+    from: 'edge_of_screen',
+    animation: 'fluid_morph_and_settle',
+    duration: '1500ms',
+    easing: 'ease_out_elastic',
+  },
+};
+
+export const hoverEffectPresets: Record<string, HoverEffectPreset> = {
+  subtle_glow: {
+    name: 'subtle_glow',
+    description: 'soft luminous glow with slight dimming for neighbors',
+    targetModifiers: {
+      gridDensity: 1.05,
+      colorIntensity: 1.2,
+      reactivity: 1.05,
+    },
+    othersModifiers: {
+      gridDensity: 0.9,
+      colorIntensity: 0.92,
+    },
+    transitionSpeedMultiplier: 0.8,
+    accentTargetModifiers: {
+      gridDensity: 1.15,
+      colorIntensity: 1.25,
+      reactivity: 1.12,
+      depth: 6,
+    },
+    accentOthersModifiers: {
+      gridDensity: 0.92,
+      colorIntensity: 0.9,
+      reactivity: 0.95,
+      depth: -3,
+    },
+    complementTargetModifiers: {
+      gridDensity: 1.08,
+      colorIntensity: 1.1,
+      reactivity: 1.06,
+      depth: 2,
+    },
+    complementOthersModifiers: {
+      gridDensity: 0.95,
+      colorIntensity: 0.94,
+      depth: -2,
+    },
+    accentTransitionSpeedMultiplier: 0.9,
+    complementTransitionSpeedMultiplier: 0.85,
+    accentEffect: { type: 'hover_accent_glow', duration: 420 },
+    complementEffect: { type: 'hover_complement_echo', duration: 360 },
+  },
+  magnetic_attraction: {
+    name: 'magnetic_attraction',
+    description: 'density increase with subtle pull and push dynamics',
+    targetModifiers: {
+      gridDensity: 1.25,
+      colorIntensity: 1.1,
+      reactivity: 1.15,
+      depth: 6,
+    },
+    othersModifiers: {
+      gridDensity: 0.8,
+      reactivity: 0.9,
+      depth: -4,
+    },
+    transitionSpeedMultiplier: 1.0,
+    accentTargetModifiers: {
+      gridDensity: 1.32,
+      colorIntensity: 1.18,
+      reactivity: 1.28,
+      depth: 12,
+    },
+    accentOthersModifiers: {
+      gridDensity: 0.75,
+      reactivity: 0.88,
+      depth: -8,
+    },
+    complementTargetModifiers: {
+      gridDensity: 1.16,
+      colorIntensity: 1.14,
+      reactivity: 1.12,
+      depth: 4,
+    },
+    complementOthersModifiers: {
+      gridDensity: 0.85,
+      colorIntensity: 0.9,
+      depth: -3,
+    },
+    accentTransitionSpeedMultiplier: 1.05,
+    complementTransitionSpeedMultiplier: 0.95,
+    accentEffect: { type: 'hover_magnetic_arc', duration: 520 },
+    complementEffect: { type: 'hover_counterwave', duration: 440 },
+  },
+  reality_distortion: {
+    name: 'reality_distortion',
+    description: 'geometry warping and stability compensation for others',
+    targetModifiers: {
+      gridDensity: 1.4,
+      colorIntensity: 1.35,
+      reactivity: 1.4,
+      depth: 10,
+    },
+    othersModifiers: {
+      gridDensity: 0.7,
+      colorIntensity: 0.85,
+      reactivity: 0.8,
+      depth: -6,
+    },
+    transitionSpeedMultiplier: 1.2,
+    accentTargetModifiers: {
+      gridDensity: 1.5,
+      colorIntensity: 1.45,
+      reactivity: 1.5,
+      depth: 16,
+    },
+    accentOthersModifiers: {
+      gridDensity: 0.68,
+      colorIntensity: 0.8,
+      reactivity: 0.75,
+      depth: -10,
+    },
+    complementTargetModifiers: {
+      gridDensity: 1.28,
+      colorIntensity: 1.22,
+      reactivity: 1.18,
+      depth: 6,
+    },
+    complementOthersModifiers: {
+      gridDensity: 0.78,
+      colorIntensity: 0.88,
+      depth: -4,
+    },
+    accentTransitionSpeedMultiplier: 1.35,
+    complementTransitionSpeedMultiplier: 1.1,
+    accentEffect: { type: 'hover_reality_wave', duration: 640 },
+    complementEffect: { type: 'hover_anchor_field', duration: 520 },
+  },
+};
+
+export const clickEffectPresets: Record<string, ClickEffectPreset> = {
+  color_inversion: {
+    name: 'color_inversion',
+    description: 'full spectrum flip with exponential decay',
+    colorInversionType: 'spectrum_flip',
+    inversionDuration: 2000,
+    decayCurve: 'exponential',
+    sparkleDuration: 1500,
+    sparkleCount: 8,
+    targetModifiers: {
+      gridDensity: 1.18,
+      colorIntensity: 1.22,
+      reactivity: 1.2,
+      depth: 8,
+    },
+    othersModifiers: {
+      gridDensity: 0.88,
+      colorIntensity: 0.92,
+      reactivity: 0.9,
+      depth: -4,
+    },
+    accentTargetModifiers: {
+      gridDensity: 1.32,
+      colorIntensity: 1.38,
+      reactivity: 1.35,
+      depth: 14,
+    },
+    accentOthersModifiers: {
+      gridDensity: 0.82,
+      colorIntensity: 0.88,
+      reactivity: 0.84,
+      depth: -7,
+    },
+    complementTargetModifiers: {
+      gridDensity: 1.12,
+      colorIntensity: 1.16,
+      reactivity: 1.1,
+      depth: 5,
+    },
+    complementOthersModifiers: {
+      gridDensity: 0.9,
+      colorIntensity: 0.94,
+      reactivity: 0.92,
+      depth: -3,
+    },
+    accentSparkleDuration: 1100,
+    accentSparkleCount: 12,
+    accentRippleDuration: 950,
+    complementarySparkleDuration: 900,
+    complementarySparkleCount: 10,
+    complementaryRippleDuration: 780,
+  },
+  reality_glitch: {
+    name: 'reality_glitch',
+    description: 'digital artifact burst with linear decay',
+    colorInversionType: 'digital_artifact_generation',
+    inversionDuration: 1500,
+    decayCurve: 'linear',
+    sparkleDuration: 1200,
+    sparkleCount: 12,
+    targetModifiers: {
+      gridDensity: 1.24,
+      colorIntensity: 1.3,
+      reactivity: 1.28,
+      depth: 10,
+    },
+    othersModifiers: {
+      gridDensity: 0.84,
+      colorIntensity: 0.88,
+      reactivity: 0.86,
+      depth: -6,
+    },
+    accentTargetModifiers: {
+      gridDensity: 1.38,
+      colorIntensity: 1.44,
+      reactivity: 1.4,
+      depth: 18,
+    },
+    accentOthersModifiers: {
+      gridDensity: 0.78,
+      colorIntensity: 0.82,
+      reactivity: 0.8,
+      depth: -9,
+    },
+    complementTargetModifiers: {
+      gridDensity: 1.16,
+      colorIntensity: 1.2,
+      reactivity: 1.15,
+      depth: 6,
+    },
+    complementOthersModifiers: {
+      gridDensity: 0.88,
+      colorIntensity: 0.9,
+      reactivity: 0.9,
+      depth: -4,
+    },
+    accentSparkleDuration: 1300,
+    accentSparkleCount: 18,
+    accentRippleDuration: 1200,
+    complementarySparkleDuration: 1000,
+    complementarySparkleCount: 14,
+    complementaryRippleDuration: 880,
+  },
+  quantum_collapse: {
+    name: 'quantum_collapse',
+    description: 'parameter randomization then stabilization with sigmoid decay',
+    colorInversionType: 'parameter_randomization_then_stabilization',
+    inversionDuration: 3000,
+    decayCurve: 'sigmoid',
+    sparkleDuration: 2000,
+    sparkleCount: 16,
+    targetModifiers: {
+      gridDensity: 1.3,
+      colorIntensity: 1.32,
+      reactivity: 1.34,
+      depth: 12,
+    },
+    othersModifiers: {
+      gridDensity: 0.8,
+      colorIntensity: 0.85,
+      reactivity: 0.82,
+      depth: -7,
+    },
+    accentTargetModifiers: {
+      gridDensity: 1.48,
+      colorIntensity: 1.5,
+      reactivity: 1.46,
+      depth: 20,
+    },
+    accentOthersModifiers: {
+      gridDensity: 0.75,
+      colorIntensity: 0.8,
+      reactivity: 0.78,
+      depth: -11,
+    },
+    complementTargetModifiers: {
+      gridDensity: 1.2,
+      colorIntensity: 1.18,
+      reactivity: 1.16,
+      depth: 7,
+    },
+    complementOthersModifiers: {
+      gridDensity: 0.88,
+      colorIntensity: 0.9,
+      reactivity: 0.88,
+      depth: -5,
+    },
+    accentSparkleDuration: 1600,
+    accentSparkleCount: 22,
+    accentRippleDuration: 1500,
+    complementarySparkleDuration: 1300,
+    complementarySparkleCount: 18,
+    complementaryRippleDuration: 1100,
+  },
+};
+
+export const scrollEffectPresets: Record<string, ScrollEffectPreset> = {
+  momentum_trails: {
+    name: 'momentum_trails',
+    description: 'motion blur particles proportional to velocity',
+    intensityModel: 'velocity',
+    decayModel: 'physics',
+    accentModifiers: {
+      gridDensity: 1.12,
+      colorIntensity: 1.18,
+      reactivity: 1.22,
+      depth: 4,
+    },
+    complementaryModifiers: {
+      gridDensity: 0.94,
+      colorIntensity: 0.92,
+      reactivity: 0.9,
+      depth: -3,
+    },
+    accentEffect: { type: 'scroll_trail_flare', duration: 600 },
+    complementaryEffect: { type: 'scroll_trail_echo', duration: 520 },
+  },
+  chaos_buildup: {
+    name: 'chaos_buildup',
+    description: 'progressive distortion released as a portal burst',
+    intensityModel: 'threshold',
+    decayModel: 'burst',
+    threshold: 5,
+    releaseBehavior: 'portal_burst',
+    accentModifiers: {
+      gridDensity: 1.3,
+      colorIntensity: 1.26,
+      reactivity: 1.28,
+      depth: 12,
+    },
+    complementaryModifiers: {
+      gridDensity: 0.9,
+      colorIntensity: 0.88,
+      reactivity: 0.9,
+      depth: -5,
+    },
+    accentEffect: { type: 'scroll_chaos_burst', duration: 720 },
+    complementaryEffect: { type: 'scroll_grounding_field', duration: 640 },
+  },
+  harmonic_resonance: {
+    name: 'harmonic_resonance',
+    description: 'coordinated frequency modulation across visualizers',
+    intensityModel: 'harmonic',
+    decayModel: 'wave',
+    accentModifiers: {
+      gridDensity: 1.18,
+      colorIntensity: 1.22,
+      reactivity: 1.2,
+      depth: 8,
+    },
+    complementaryModifiers: {
+      gridDensity: 0.92,
+      colorIntensity: 0.9,
+      reactivity: 0.92,
+      depth: -4,
+    },
+    accentEffect: { type: 'scroll_resonance_chorus', duration: 680 },
+    complementaryEffect: { type: 'scroll_resonance_counter', duration: 580 },
+  },
+};
+
+export const accentOverlayPresets: Record<string, ParameterPatch> = {
+  chromatic_stitching: { chromaShift: 0.08, density: 1.1 },
+  plasma_highlights: { dispAmp: 0.25, timeScale: 1.1 },
+  halo_bloom: { morph: 1.05, chromaShift: 0.12 },
+};
+
+export const complementaryOverlayPresets: Record<string, ParameterPatch> = {
+  anchoring_grid: { density: 0.92, glitch: 0.02 },
+  mist_envelope: { dispAmp: 0.18, chaos: 0.1 },
+  ground_fog: { morph: 0.94, chromaShift: 0.03 },
+};
+
+export const DEFAULT_DESIGN_SYSTEM_SELECTIONS: DesignSystemSelections = {
+  visualizer: 'standard',
+  speed: 'flowing',
+  reactivity: 'responsive',
+  color: 'complementary',
+  hoverEffect: 'magnetic_attraction',
+  clickEffect: 'color_inversion',
+  scrollEffect: 'momentum_trails',
+  pageTransition: 'slide_portal',
+  cardTransition: 'gentle_emerge',
+  accentOverlay: 'chromatic_stitching',
+  complementaryOverlay: 'anchoring_grid',
+};
+
+export const DEFAULT_ADVANCED_TUNING: DesignSystemAdvancedTuning = {
+  speedMultiplier: 1.0,
+  interactionSensitivity: 1.0,
+  transitionDurationMultiplier: 1.0,
+};
+

--- a/lib/design-system/transition-coordinator.ts
+++ b/lib/design-system/transition-coordinator.ts
@@ -1,0 +1,73 @@
+import { CARD_TRANSITIONS_STATES, TRANSITION_COORDINATION } from './constants';
+import {
+  CardTransitionEntry,
+  CardTransitionsDefinition,
+  CoordinatedPhaseDefinition,
+  DesignSystemAdvancedTuning,
+} from './types';
+
+export interface TransitionPhaseSchedule {
+  phase: string;
+  start: number;
+  end: number;
+}
+
+const parseRange = (range: string): [number, number] => {
+  const match = range.match(/([0-9.]+)ms-([0-9.]+)ms/);
+  if (!match) return [0, 0];
+  return [parseFloat(match[1]), parseFloat(match[2])];
+};
+
+const buildSchedule = (
+  definition: CoordinatedPhaseDefinition,
+  multiplier: number
+): TransitionPhaseSchedule[] => {
+  const phases: Array<['phase1' | 'phase2' | 'phase3' | 'phase4', string]> = [
+    ['phase1', definition.phase1],
+    ['phase2', definition.phase2],
+    ['phase3', definition.phase3],
+    ['phase4', definition.phase4],
+  ];
+
+  return phases.map(([key, label]) => {
+    const range = definition.timing[key];
+    const [start, end] = parseRange(range);
+    return {
+      phase: label,
+      start: start * multiplier,
+      end: end * multiplier,
+    };
+  });
+};
+
+export class TransitionCoordinator {
+  constructor(
+    private coordination = TRANSITION_COORDINATION,
+    private cardTransitions: CardTransitionsDefinition = CARD_TRANSITIONS_STATES
+  ) {}
+
+  getOutgoingTimeline(tuning: DesignSystemAdvancedTuning): TransitionPhaseSchedule[] {
+    return buildSchedule(
+      this.coordination.outgoing,
+      tuning.transitionDurationMultiplier
+    );
+  }
+
+  getIncomingTimeline(tuning: DesignSystemAdvancedTuning): TransitionPhaseSchedule[] {
+    return buildSchedule(
+      this.coordination.incoming,
+      tuning.transitionDurationMultiplier
+    );
+  }
+
+  getCardTransition(type: 'emergence' | 'submersion', variant: string): CardTransitionEntry | undefined {
+    return this.cardTransitions[type][variant];
+  }
+
+  describeMathematicalRelationship(): Record<string, string> {
+    return this.coordination.mathematical_relationship;
+  }
+}
+
+export const createTransitionCoordinator = () => new TransitionCoordinator();
+

--- a/lib/design-system/types.ts
+++ b/lib/design-system/types.ts
@@ -1,0 +1,422 @@
+// Design system type definitions derived from the VIB34D architecture
+
+export type InteractionOperation = string;
+
+export interface HoverBehaviorOperations {
+  gridDensity: InteractionOperation;
+  colorIntensity: InteractionOperation;
+  reactivity: InteractionOperation;
+  depth: InteractionOperation;
+}
+
+export interface HoverTransitionDefinition {
+  duration: string;
+  easing: string;
+  stagger: string;
+}
+
+export interface HoverLayerDefinition {
+  target: HoverBehaviorOperations;
+  others: HoverBehaviorOperations;
+}
+
+export interface HoverResponseDefinition {
+  target: HoverBehaviorOperations;
+  others: HoverBehaviorOperations;
+  accent?: HoverLayerDefinition;
+  complementary?: HoverLayerDefinition;
+  transition: HoverTransitionDefinition;
+}
+
+export interface ClickVariableInversionDefinition {
+  speed: InteractionOperation;
+  density: InteractionOperation;
+  intensity: InteractionOperation;
+}
+
+export interface ClickImmediateDefinition {
+  colorInversion: InteractionOperation;
+  variableInversion: ClickVariableInversionDefinition;
+  rippleEffect: InteractionOperation;
+  sparkleGeneration: InteractionOperation;
+}
+
+export interface ClickDurationDefinition {
+  inversion: string;
+  decay: string;
+  sparkles: string;
+}
+
+export interface ClickPulseDefinition extends HoverLayerDefinition {
+  rippleEffect: InteractionOperation;
+  sparkleGeneration: InteractionOperation;
+  duration: string;
+}
+
+export interface ClickResponseDefinition {
+  primary: HoverLayerDefinition;
+  immediate: ClickImmediateDefinition;
+  duration: ClickDurationDefinition;
+  accent?: ClickPulseDefinition;
+  complementary?: ClickPulseDefinition;
+}
+
+export interface CoordinatedPhaseDefinition {
+  phase1: string;
+  phase2: string;
+  phase3: string;
+  phase4: string;
+  timing: {
+    phase1: string;
+    phase2: string;
+    phase3: string;
+    phase4: string;
+  };
+}
+
+export interface TransitionCoordinationDefinition {
+  outgoing: CoordinatedPhaseDefinition;
+  incoming: CoordinatedPhaseDefinition;
+  accent?: CoordinatedPhaseDefinition;
+  complementary?: CoordinatedPhaseDefinition;
+  mathematical_relationship: {
+    density_conservation: string;
+    color_harmonic: string;
+    geometric_morphing: string;
+  };
+}
+
+export interface CardTransitionEntry {
+  translucency?: string;
+  depth?: string;
+  scale?: string;
+  geometry_sync?: string;
+  duration: string;
+  rotation?: string;
+  blur?: string;
+  emergence_point?: string;
+  convergence_point?: string;
+}
+
+export interface CardTransitionsDefinition {
+  emergence: Record<string, CardTransitionEntry>;
+  submersion: Record<string, CardTransitionEntry>;
+  accent?: Record<string, CardTransitionEntry>;
+  complementary?: Record<string, CardTransitionEntry>;
+}
+
+export interface VisualizerDensityPreset {
+  base: number;
+  variation: number;
+}
+
+export interface VisualizerSpeedPreset {
+  base: number;
+  variation: number;
+}
+
+export interface VisualizerReactivityPreset {
+  mouse: number;
+  click: number;
+  scroll: number;
+}
+
+export interface VisualizerColorPreset {
+  palette: string;
+}
+
+export interface PageTransitionPreset {
+  outgoing: string;
+  incoming: string;
+  overlap: string;
+  easing: string;
+}
+
+export interface CardTransitionPreset {
+  from: string;
+  animation: string;
+  duration: string;
+  easing: string;
+}
+
+export interface HoverEffectPreset {
+  name: string;
+  description: string;
+  targetModifiers: Partial<VisualStateMultipliers>;
+  othersModifiers: Partial<VisualStateMultipliers>;
+  transitionSpeedMultiplier: number;
+  accentTargetModifiers?: Partial<VisualStateMultipliers>;
+  accentOthersModifiers?: Partial<VisualStateMultipliers>;
+  complementTargetModifiers?: Partial<VisualStateMultipliers>;
+  complementOthersModifiers?: Partial<VisualStateMultipliers>;
+  accentTransitionSpeedMultiplier?: number;
+  complementTransitionSpeedMultiplier?: number;
+  accentEffect?: { type: string; duration: number };
+  complementEffect?: { type: string; duration: number };
+}
+
+export interface ClickEffectPreset {
+  name: string;
+  description: string;
+  colorInversionType: string;
+  inversionDuration: number;
+  decayCurve: 'exponential' | 'linear' | 'sigmoid';
+  sparkleDuration: number;
+  sparkleCount: number;
+  targetModifiers?: Partial<VisualStateMultipliers>;
+  othersModifiers?: Partial<VisualStateMultipliers>;
+  accentTargetModifiers?: Partial<VisualStateMultipliers>;
+  accentOthersModifiers?: Partial<VisualStateMultipliers>;
+  complementTargetModifiers?: Partial<VisualStateMultipliers>;
+  complementOthersModifiers?: Partial<VisualStateMultipliers>;
+  accentSparkleDuration?: number;
+  accentSparkleCount?: number;
+  accentRippleDuration?: number;
+  complementarySparkleDuration?: number;
+  complementarySparkleCount?: number;
+  complementaryRippleDuration?: number;
+}
+
+export interface ScrollEffectPreset {
+  name: string;
+  description: string;
+  intensityModel: 'velocity' | 'threshold' | 'harmonic';
+  decayModel: 'physics' | 'burst' | 'wave';
+  threshold?: number;
+  releaseBehavior?: string;
+  accentModifiers?: Partial<VisualStateMultipliers>;
+  complementaryModifiers?: Partial<VisualStateMultipliers>;
+  accentEffect?: { type: string; duration: number };
+  complementaryEffect?: { type: string; duration: number };
+}
+
+export interface VisualStateMultipliers {
+  gridDensity?: number;
+  colorIntensity?: number;
+  reactivity?: number;
+  depth?: number;
+}
+
+export interface InteractionEffectState {
+  type: string;
+  startedAt: number;
+  duration: number;
+  data?: Record<string, number | string>;
+}
+
+export interface LayerVisualState {
+  gridDensity: number;
+  colorIntensity: number;
+  reactivity: number;
+  depth: number;
+  lastUpdated: number;
+}
+
+export interface SectionVisualState extends LayerVisualState {
+  inversionActiveUntil?: number;
+  rippleEffect?: InteractionEffectState;
+  sparkleEffect?: InteractionEffectState & { count: number };
+  accentLayer?: LayerVisualState;
+  complementaryLayer?: LayerVisualState;
+  accentEffect?: InteractionEffectState;
+  complementaryEffect?: InteractionEffectState;
+}
+
+export type ParameterPatch = Partial<{
+  density: number;
+  morph: number;
+  chaos: number;
+  noiseFreq: number;
+  glitch: number;
+  dispAmp: number;
+  chromaShift: number;
+  timeScale: number;
+}>;
+
+export interface MinimalParamsSnapshot {
+  density: number;
+  morph: number;
+  chaos: number;
+  noiseFreq: number;
+  glitch: number;
+  dispAmp: number;
+  chromaShift: number;
+  timeScale: number;
+}
+
+export type SectionParameterSnapshot = Record<string, MinimalParamsSnapshot>;
+
+export interface HoverInteractionResult {
+  sectionStates: Record<string, SectionVisualState>;
+  paramPatches: Record<string, ParameterPatch>;
+  transitionDuration: number;
+  transitionEasing: string;
+  stagger: number;
+}
+
+export interface ClickInteractionResult {
+  sectionStates: Record<string, SectionVisualState>;
+  paramPatches: Record<string, ParameterPatch>;
+}
+
+export interface ScrollInteractionResult {
+  sectionStates: Record<string, SectionVisualState>;
+  paramPatches: Record<string, ParameterPatch>;
+}
+
+export interface DesignSystemSelections {
+  visualizer: string;
+  speed: string;
+  reactivity: string;
+  color: string;
+  hoverEffect: string;
+  clickEffect: string;
+  scrollEffect: string;
+  pageTransition: string;
+  cardTransition: string;
+  accentOverlay: string;
+  complementaryOverlay: string;
+}
+
+export interface DesignSystemAdvancedTuning {
+  speedMultiplier: number;
+  interactionSensitivity: number;
+  transitionDurationMultiplier: number;
+}
+
+export interface DesignSystemStateSlice {
+  selections: DesignSystemSelections;
+  advanced: DesignSystemAdvancedTuning;
+  sectionStates: Record<string, SectionVisualState>;
+  lastInteraction?: {
+    type: 'hover' | 'click' | 'scroll';
+    at: number;
+    sectionId?: string;
+  };
+  customPresets: Record<string, ParameterPatch>;
+  reactivitySettings?: VisualizerReactivityPreset;
+  colorPalette?: VisualizerColorPreset;
+}
+
+export interface EditorControlOption {
+  label: string;
+  value: string;
+}
+
+export interface EditorControlDefinition {
+  id: string;
+  type: 'dropdown' | 'slider' | 'toggle' | 'button' | 'sortable_list';
+  label: string;
+  options?: EditorControlOption[];
+  range?: [number, number];
+  step?: number;
+  defaultValue?: number | string;
+  livePreview?: boolean;
+  actions?: string[];
+  subOptions?: Record<string, string[]>;
+  previewActionId?: string;
+}
+
+export interface EditorSectionDefinition {
+  id: string;
+  title: string;
+  controls: EditorControlDefinition[];
+}
+
+export interface EditorPanelDefinition {
+  id: string;
+  sections: EditorSectionDefinition[];
+}
+
+export interface ContentSectionBehaviorDefinition {
+  id: string;
+  type: 'dropdown' | 'toggle';
+  options: string[];
+  subOptions?: Record<string, string[]>;
+}
+
+export interface ContentManagementDefinition {
+  sections: ContentSectionBehaviorDefinition[];
+  actions: EditorControlDefinition[];
+  accentSettings?: ContentAccentSettingDefinition[];
+}
+
+export interface ContentAccentSettingDefinition {
+  id: string;
+  label: string;
+  description: string;
+  defaultState: string;
+}
+
+export interface ScrollableGridLayoutDefinition {
+  columns: string;
+  gap: string;
+  scroll_behavior: string;
+  scroll_snap: string;
+  virtualization: string;
+}
+
+export interface ScrollableVisualizerResponseDefinition {
+  scroll_up: string;
+  scroll_down: string;
+  scroll_velocity: string;
+  scroll_momentum: string;
+}
+
+export interface ScrollableContentBehaviorDefinition {
+  snap_points: string;
+  momentum_scrolling: string;
+  edge_bouncing: string;
+}
+
+export interface ScrollableAccentLayerDefinition {
+  accent_channel: string;
+  complementary_channel: string;
+  effect_sync: string;
+  intensity_curve: string;
+}
+
+export interface ScrollableCardsDefinition {
+  grid_layout: ScrollableGridLayoutDefinition;
+  scroll_interactions: {
+    visualizer_response: ScrollableVisualizerResponseDefinition;
+    content_behavior: ScrollableContentBehaviorDefinition;
+  };
+  accent_layers?: {
+    accent: ScrollableAccentLayerDefinition;
+    complementary: ScrollableAccentLayerDefinition;
+  };
+}
+
+export interface VideoExpansionStateDefinition {
+  size: string;
+  visualizer_role: string;
+  play_button_overlay?: string;
+  z_index?: string;
+  background_blur?: string;
+  controls: string;
+  background?: string;
+}
+
+export interface VideoExpansionTransitionsDefinition {
+  duration: string;
+  easing: string;
+  visualizer_morph: string;
+}
+
+export interface VideoExpansionDefinition {
+  expansion_states: {
+    thumbnail: VideoExpansionStateDefinition;
+    playing: VideoExpansionStateDefinition;
+    fullscreen: VideoExpansionStateDefinition;
+  };
+  transitions: {
+    thumbnail_to_playing: VideoExpansionTransitionsDefinition;
+    playing_to_fullscreen: VideoExpansionTransitionsDefinition;
+  };
+  accent_layers?: {
+    accent: { effect: string; duration: string; overlay: string };
+    complementary: { effect: string; duration: string; overlay: string };
+  };
+}
+

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,6 +7,31 @@
 
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
+import {
+  DEFAULT_ADVANCED_TUNING,
+  DEFAULT_DESIGN_SYSTEM_SELECTIONS,
+  UNIVERSAL_HOVER_RESPONSE,
+  UNIVERSAL_CLICK_RESPONSE,
+  hoverEffectPresets,
+  clickEffectPresets,
+  scrollEffectPresets,
+  createPresetManager,
+  applyHoverInteraction,
+  applyClickInteraction,
+  applyScrollInteraction,
+  resetSectionVisualStates,
+  pruneExpiredEffects,
+  createDefaultSectionVisualState,
+} from '@/lib/design-system';
+import type {
+  DesignSystemAdvancedTuning,
+  DesignSystemStateSlice,
+  MinimalParamsSnapshot,
+  ParameterPatch,
+  PresetCategory,
+  SectionParameterSnapshot,
+  SectionVisualState,
+} from '@/lib/design-system';
 
 // EXACT PARAMETER VOCABULARY from PDF specification
 export interface Params {
@@ -163,6 +188,14 @@ export const COUPLING_FACTORS = {
   glitch: 0.15,
 };
 
+const presetManager = createPresetManager();
+
+const createInitialSectionStates = (): Record<string, SectionVisualState> =>
+  Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+    acc[sectionId] = createDefaultSectionVisualState();
+    return acc;
+  }, {} as Record<string, SectionVisualState>);
+
 // State interface
 interface StoreState {
   // Core parameter state
@@ -170,16 +203,19 @@ interface StoreState {
   sections: Record<string, Params>;
   focus?: string;
   beatPhase: number;
-  
+
   // Interaction state
   isHovering: boolean;
   hoverSection?: string;
   scrollProgress: number;
-  
+
   // Audio reactivity
   audioEnabled: boolean;
   audioData: Float32Array | null;
-  
+
+  // Design system
+  designSystem: DesignSystemStateSlice;
+
   // Events and actions
   events: {
     HOVER_START: (id: string) => void;
@@ -190,6 +226,13 @@ interface StoreState {
     UPDATE_HOME: (params: Partial<Params>) => void;
     RANDOMIZE_HOME: () => void;
     TOGGLE_AUDIO: () => void;
+    APPLY_HOVER_RESPONSE: (id: string) => void;
+    APPLY_CLICK_RESPONSE: (id: string) => void;
+    APPLY_SCROLL_RESPONSE: (direction: 'up' | 'down', velocity: number) => void;
+    SET_PRESET: (category: PresetCategory, name: string) => void;
+    SET_ADVANCED_TUNING: (key: keyof DesignSystemAdvancedTuning, value: number) => void;
+    CREATE_CUSTOM_PRESET: (name: string, patch: ParameterPatch) => void;
+    RESET_SECTION_VISUAL_STATE: (sectionId?: string) => void;
   };
 }
 
@@ -250,6 +293,242 @@ export function randomizeHomeParams(): Params {
   };
 }
 
+const computeSectionParams = (
+  home: Params,
+  sections: Record<string, Params>
+): Record<string, Params> => {
+  const resolved: Record<string, Params> = { ...sections };
+  Object.keys(SECTION_CONFIGS).forEach((sectionId) => {
+    if (!resolved[sectionId]) {
+      resolved[sectionId] = deriveParams(home, SECTION_CONFIGS[sectionId].offsets);
+    }
+  });
+  return resolved;
+};
+
+const buildParamsSnapshot = (sections: Record<string, Params>): SectionParameterSnapshot => {
+  return Object.entries(sections).reduce((acc, [sectionId, params]) => {
+    acc[sectionId] = {
+      density: params.density,
+      morph: params.morph,
+      chaos: params.chaos,
+      noiseFreq: params.noiseFreq,
+      glitch: params.glitch,
+      dispAmp: params.dispAmp,
+      chromaShift: params.chromaShift,
+      timeScale: params.timeScale,
+    };
+    return acc;
+  }, {} as SectionParameterSnapshot);
+};
+
+const applyParameterPatches = (
+  sections: Record<string, Params>,
+  patches: Record<string, ParameterPatch>
+): Record<string, Params> => {
+  const updated = { ...sections };
+  Object.entries(patches).forEach(([sectionId, patch]) => {
+    const base = updated[sectionId];
+    if (!base) return;
+    updated[sectionId] = { ...base, ...patch };
+  });
+  return updated;
+};
+
+const toMinimalSnapshot = (params: Params): MinimalParamsSnapshot => ({
+  density: params.density,
+  morph: params.morph,
+  chaos: params.chaos,
+  noiseFreq: params.noiseFreq,
+  glitch: params.glitch,
+  dispAmp: params.dispAmp,
+  chromaShift: params.chromaShift,
+  timeScale: params.timeScale,
+});
+
+const computeHoverResponse = (
+  input: { home: Params; sections: Record<string, Params>; designSystem: DesignSystemStateSlice },
+  targetId: string,
+  timestamp: number
+) => {
+  const ensuredSections = computeSectionParams(input.home, input.sections);
+  let updatedSections = { ...ensuredSections };
+
+  if (SECTION_CONFIGS[targetId]?.transitionIn === 'oppose_snap') {
+    Object.keys(SECTION_CONFIGS).forEach((sectionId) => {
+      if (sectionId !== targetId) {
+        const currentParams = updatedSections[sectionId] || deriveParams(input.home, SECTION_CONFIGS[sectionId].offsets);
+        updatedSections[sectionId] = {
+          ...currentParams,
+          hue: 1.0 - currentParams.hue,
+          density: currentParams.density * 0.85,
+          chromaShift: currentParams.chromaShift + 0.05,
+        };
+      }
+    });
+  }
+
+  const snapshot = buildParamsSnapshot(updatedSections);
+  const hoverEffect =
+    hoverEffectPresets[input.designSystem.selections.hoverEffect] ||
+    hoverEffectPresets.subtle_glow;
+
+  const hoverResult = applyHoverInteraction({
+    targetId,
+    sectionStates: input.designSystem.sectionStates,
+    params: snapshot,
+    hoverResponse: UNIVERSAL_HOVER_RESPONSE,
+    effect: hoverEffect,
+    advanced: input.designSystem.advanced,
+    timestamp,
+  });
+  const accentOverlay =
+    (presetManager.get('accentOverlay', input.designSystem.selections.accentOverlay) as ParameterPatch | undefined) ??
+    undefined;
+  const complementaryOverlay =
+    (presetManager.get('complementaryOverlay', input.designSystem.selections.complementaryOverlay) as
+      | ParameterPatch
+      | undefined) ?? undefined;
+
+  const overlayPatches: Record<string, ParameterPatch> = { ...hoverResult.paramPatches };
+
+  if (accentOverlay) {
+    overlayPatches[targetId] = overlayPatches[targetId]
+      ? { ...overlayPatches[targetId], ...accentOverlay }
+      : { ...accentOverlay };
+  }
+
+  if (complementaryOverlay) {
+    Object.keys(updatedSections).forEach((sectionId) => {
+      if (sectionId === targetId) return;
+      overlayPatches[sectionId] = overlayPatches[sectionId]
+        ? { ...overlayPatches[sectionId], ...complementaryOverlay }
+        : { ...complementaryOverlay };
+    });
+  }
+
+  const sections = applyParameterPatches(updatedSections, overlayPatches);
+  const designSystem: DesignSystemStateSlice = {
+    ...input.designSystem,
+    sectionStates: hoverResult.sectionStates,
+    lastInteraction: { type: 'hover', at: timestamp, sectionId: targetId },
+  };
+
+  return { sections, designSystem };
+};
+
+const computeClickResponse = (
+  input: { home: Params; sections: Record<string, Params>; designSystem: DesignSystemStateSlice },
+  targetId: string,
+  timestamp: number
+) => {
+  const ensuredSections = computeSectionParams(input.home, input.sections);
+  const snapshot = buildParamsSnapshot(ensuredSections);
+  const clickEffect =
+    clickEffectPresets[input.designSystem.selections.clickEffect] ||
+    clickEffectPresets.color_inversion;
+
+  const clickResult = applyClickInteraction({
+    targetId,
+    sectionStates: input.designSystem.sectionStates,
+    params: snapshot,
+    clickResponse: UNIVERSAL_CLICK_RESPONSE,
+    effect: clickEffect,
+    advanced: input.designSystem.advanced,
+    timestamp,
+  });
+  const accentOverlay =
+    (presetManager.get('accentOverlay', input.designSystem.selections.accentOverlay) as ParameterPatch | undefined) ??
+    undefined;
+  const complementaryOverlay =
+    (presetManager.get('complementaryOverlay', input.designSystem.selections.complementaryOverlay) as
+      | ParameterPatch
+      | undefined) ?? undefined;
+
+  const overlayPatches: Record<string, ParameterPatch> = { ...clickResult.paramPatches };
+
+  if (accentOverlay) {
+    overlayPatches[targetId] = overlayPatches[targetId]
+      ? { ...overlayPatches[targetId], ...accentOverlay }
+      : { ...accentOverlay };
+  }
+
+  if (complementaryOverlay) {
+    Object.keys(snapshot).forEach((sectionId) => {
+      if (sectionId === targetId) return;
+      overlayPatches[sectionId] = overlayPatches[sectionId]
+        ? { ...overlayPatches[sectionId], ...complementaryOverlay }
+        : { ...complementaryOverlay };
+    });
+  }
+
+  const sections = applyParameterPatches(ensuredSections, overlayPatches);
+  const designSystem: DesignSystemStateSlice = {
+    ...input.designSystem,
+    sectionStates: clickResult.sectionStates,
+    lastInteraction: { type: 'click', at: timestamp, sectionId: targetId },
+  };
+
+  return { sections, designSystem };
+};
+
+const computeScrollResponse = (
+  input: { home: Params; sections: Record<string, Params>; designSystem: DesignSystemStateSlice },
+  direction: 'up' | 'down',
+  velocity: number,
+  timestamp: number
+) => {
+  const ensuredSections = computeSectionParams(input.home, input.sections);
+  const snapshot = buildParamsSnapshot(ensuredSections);
+  const scrollEffect =
+    scrollEffectPresets[input.designSystem.selections.scrollEffect] ||
+    scrollEffectPresets.momentum_trails;
+
+  const scrollResult = applyScrollInteraction({
+    direction,
+    velocity,
+    sectionStates: input.designSystem.sectionStates,
+    params: snapshot,
+    effect: scrollEffect,
+    advanced: input.designSystem.advanced,
+    timestamp,
+  });
+  const accentOverlay =
+    (presetManager.get('accentOverlay', input.designSystem.selections.accentOverlay) as ParameterPatch | undefined) ??
+    undefined;
+  const complementaryOverlay =
+    (presetManager.get('complementaryOverlay', input.designSystem.selections.complementaryOverlay) as
+      | ParameterPatch
+      | undefined) ?? undefined;
+
+  const overlayPatches: Record<string, ParameterPatch> = { ...scrollResult.paramPatches };
+  const accentTarget = input.designSystem.lastInteraction?.sectionId;
+
+  if (accentOverlay && accentTarget) {
+    overlayPatches[accentTarget] = overlayPatches[accentTarget]
+      ? { ...overlayPatches[accentTarget], ...accentOverlay }
+      : { ...accentOverlay };
+  }
+
+  if (complementaryOverlay) {
+    Object.keys(snapshot).forEach((sectionId) => {
+      if (accentTarget && sectionId === accentTarget) return;
+      overlayPatches[sectionId] = overlayPatches[sectionId]
+        ? { ...overlayPatches[sectionId], ...complementaryOverlay }
+        : { ...complementaryOverlay };
+    });
+  }
+
+  const sections = applyParameterPatches(ensuredSections, overlayPatches);
+  const designSystem: DesignSystemStateSlice = {
+    ...input.designSystem,
+    sectionStates: scrollResult.sectionStates,
+    lastInteraction: { type: 'scroll', at: timestamp },
+  };
+
+  return { sections, designSystem };
+};
+
 // MAIN ZUSTAND STORE
 export const useStore = create<StoreState>()(
   subscribeWithSelector((set, get) => ({
@@ -265,55 +544,74 @@ export const useStore = create<StoreState>()(
     
     audioEnabled: false,
     audioData: null,
-    
+
+    designSystem: {
+      selections: { ...DEFAULT_DESIGN_SYSTEM_SELECTIONS },
+      advanced: { ...DEFAULT_ADVANCED_TUNING },
+      sectionStates: createInitialSectionStates(),
+      lastInteraction: undefined,
+      customPresets: {},
+      reactivitySettings: presetManager.get('reactivity', DEFAULT_DESIGN_SYSTEM_SELECTIONS.reactivity) || undefined,
+      colorPalette: presetManager.get('color', DEFAULT_DESIGN_SYSTEM_SELECTIONS.color) || undefined,
+    },
+
     // Event handlers
     events: {
       HOVER_START: (id: string) => {
         set((state) => {
-          const newState = { ...state, isHovering: true, hoverSection: id };
-          
-          // Apply Oppose & Snap pattern (PDF page 3-4)
-          if (SECTION_CONFIGS[id]?.transitionIn === 'oppose_snap') {
-            const updatedSections = { ...state.sections };
-            
-            // Update all sections with complementary reactions
-            Object.keys(SECTION_CONFIGS).forEach((sectionId) => {
-              if (sectionId !== id) {
-                const currentParams = updatedSections[sectionId] || deriveParams(state.home, SECTION_CONFIGS[sectionId].offsets);
-                // Invert hue for non-focused sections
-                updatedSections[sectionId] = {
-                  ...currentParams,
-                  hue: 1.0 - currentParams.hue,
-                  density: currentParams.density * 0.85, // Coupling factor
-                  chromaShift: currentParams.chromaShift + 0.05,
-                };
-              }
-            });
-            
-            newState.sections = updatedSections;
-          }
-          
-          return newState;
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeHoverResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            id,
+            timestamp
+          );
+
+          return {
+            ...state,
+            isHovering: true,
+            hoverSection: id,
+            sections,
+            designSystem,
+          };
         });
       },
       
-      HOVER_END: (id: string) => {
-        set((state) => ({
-          ...state,
-          isHovering: false,
-          hoverSection: undefined,
-          // Reset sections to derived state
-          sections: Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+      HOVER_END: (_id: string) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const baseSections = Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
             acc[sectionId] = deriveParams(state.home, SECTION_CONFIGS[sectionId].offsets);
             return acc;
-          }, {} as Record<string, Params>),
-        }));
+          }, {} as Record<string, Params>);
+
+          const resetStates = resetSectionVisualStates(
+            state.designSystem.sectionStates,
+            Object.keys(SECTION_CONFIGS)
+          );
+
+          return {
+            ...state,
+            isHovering: false,
+            hoverSection: undefined,
+            sections: baseSections,
+            designSystem: {
+              ...state.designSystem,
+              sectionStates: resetStates,
+              lastInteraction: { type: 'hover', at: timestamp },
+            },
+          };
+        });
       },
       
       TICK: (dt: number) => {
+        const timestamp = Date.now();
         set((state) => ({
           ...state,
-          beatPhase: (state.beatPhase + dt * 0.5) % 1.0, // Update beat phase
+          beatPhase: (state.beatPhase + dt * 0.5) % 1.0,
+          designSystem: {
+            ...state.designSystem,
+            sectionStates: pruneExpiredEffects(state.designSystem.sectionStates, timestamp),
+          },
         }));
       },
       
@@ -367,6 +665,157 @@ export const useStore = create<StoreState>()(
       
       TOGGLE_AUDIO: () => {
         set((state) => ({ ...state, audioEnabled: !state.audioEnabled }));
+      },
+
+      APPLY_HOVER_RESPONSE: (id: string) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeHoverResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            id,
+            timestamp
+          );
+          return {
+            ...state,
+            sections,
+            designSystem,
+          };
+        });
+      },
+
+      APPLY_CLICK_RESPONSE: (id: string) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeClickResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            id,
+            timestamp
+          );
+          return {
+            ...state,
+            sections,
+            designSystem,
+          };
+        });
+      },
+
+      APPLY_SCROLL_RESPONSE: (direction: 'up' | 'down', velocity: number) => {
+        set((state) => {
+          const timestamp = Date.now();
+          const { sections, designSystem } = computeScrollResponse(
+            { home: state.home, sections: state.sections, designSystem: state.designSystem },
+            direction,
+            velocity,
+            timestamp
+          );
+          return {
+            ...state,
+            sections,
+            designSystem,
+          };
+        });
+      },
+
+      SET_PRESET: (category: PresetCategory, name: string) => {
+        set((state) => {
+          const selections = { ...state.designSystem.selections, [category]: name };
+          let advanced = { ...state.designSystem.advanced };
+          let reactivitySettings = state.designSystem.reactivitySettings;
+          let colorPalette = state.designSystem.colorPalette;
+          let home = state.home;
+          let sections = state.sections;
+
+          const timestamp = Date.now();
+
+          if (category === 'reactivity') {
+            const preset = presetManager.get('reactivity', name);
+            if (preset) {
+              advanced = {
+                ...advanced,
+                interactionSensitivity: preset.mouse,
+              };
+              reactivitySettings = preset;
+            }
+          }
+
+          if (category === 'color') {
+            const patch = presetManager.computeHomePatch('color', name, toMinimalSnapshot(state.home), advanced);
+            if (patch) {
+              home = { ...state.home, ...patch };
+              sections = Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+                acc[sectionId] = deriveParams(home, SECTION_CONFIGS[sectionId].offsets);
+                return acc;
+              }, {} as Record<string, Params>);
+            }
+            const preset = presetManager.get('color', name);
+            if (preset) {
+              colorPalette = preset;
+            }
+          }
+
+          if (category === 'visualizer' || category === 'speed') {
+            const patch = presetManager.computeHomePatch(category, name, toMinimalSnapshot(home), advanced);
+            if (patch) {
+              home = { ...home, ...patch };
+              sections = Object.keys(SECTION_CONFIGS).reduce((acc, sectionId) => {
+                acc[sectionId] = deriveParams(home, SECTION_CONFIGS[sectionId].offsets);
+                return acc;
+              }, {} as Record<string, Params>);
+            }
+          }
+
+          return {
+            ...state,
+            home,
+            sections,
+            designSystem: {
+              ...state.designSystem,
+              selections,
+              advanced,
+              reactivitySettings,
+              colorPalette,
+              lastInteraction: { type: 'hover', at: timestamp },
+            },
+          };
+        });
+      },
+
+      SET_ADVANCED_TUNING: (key: keyof DesignSystemAdvancedTuning, value: number) => {
+        set((state) => ({
+          ...state,
+          designSystem: {
+            ...state.designSystem,
+            advanced: {
+              ...state.designSystem.advanced,
+              [key]: value,
+            },
+          },
+        }));
+      },
+
+      CREATE_CUSTOM_PRESET: (name: string, patch: ParameterPatch) => {
+        presetManager.registerCustomPreset(name, patch);
+        set((state) => ({
+          ...state,
+          designSystem: {
+            ...state.designSystem,
+            customPresets: { ...state.designSystem.customPresets, [name]: patch },
+          },
+        }));
+      },
+
+      RESET_SECTION_VISUAL_STATE: (sectionId?: string) => {
+        set((state) => {
+          const ids = sectionId ? [sectionId] : Object.keys(SECTION_CONFIGS);
+          const resetStates = resetSectionVisualStates(state.designSystem.sectionStates, ids);
+          return {
+            ...state,
+            designSystem: {
+              ...state.designSystem,
+              sectionStates: resetStates,
+            },
+          };
+        });
       },
     },
   }))


### PR DESCRIPTION
## Summary
- extend the avant-garde background to a full five-layer holographic stack with dedicated background and shadow canvases that respond to the design-system parameters
- add accent and complementary behavior definitions, presets, and type support so hover, click, scroll, and transition pipelines emit layered visual states and effect metadata
- wire accent/complement overlays into the design-system store, preset manager, editor controls, and content integration schemas to expose configurable accent banks across the experience

## Testing
- `npm run type-check` *(fails: legacy specs under tests-backup still rely on DOM globals and downlevel iteration support)*
- `npm run lint` *(aborted: Next.js lint command prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d35772d62483299ed6c6c0e701e5aa